### PR TITLE
Add adjusted mkarchiso for loong64

### DIFF
--- a/mkarchiso
+++ b/mkarchiso
@@ -1,0 +1,2265 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e -u
+shopt -s extglob
+
+# Control the environment
+umask 0022
+export LC_ALL="C.UTF-8"
+[[ -v SOURCE_DATE_EPOCH ]] || printf -v SOURCE_DATE_EPOCH '%(%s)T' -1
+export SOURCE_DATE_EPOCH
+
+# Set application name from the script's file name
+app_name="${0##*/}"
+
+# Define global variables. All of them will be overwritten later
+pkg_list=()
+bootstrap_pkg_list=()
+quiet=""
+work_dir=""
+out_dir=""
+gpg_key=""
+gpg_sender=""
+iso_name=""
+iso_label=""
+iso_uuid=""
+iso_publisher=""
+iso_application=""
+iso_version=""
+install_dir=""
+arch=""
+pacman_conf=""
+packages=""
+bootstrap_packages=""
+bootstrap_parent=""
+pacstrap_dir=""
+search_filename=""
+declare -i rm_work_dir=0
+buildmodes=()
+bootmodes=()
+airootfs_image_type=""
+airootfs_image_tool_options=()
+bootstrap_tarball_compression=""
+cert_list=()
+declare -A file_permissions=()
+efibootimg=""
+efiboot_files=()
+# adapted from GRUB_EARLY_INITRD_LINUX_STOCK in https://git.savannah.gnu.org/cgit/grub.git/tree/util/grub-mkconfig.in
+readonly ucodes=('intel-uc.img' 'intel-ucode.img' 'amd-uc.img' 'amd-ucode.img' 'early_ucode.cpio' 'microcode.cpio')
+declare -i need_external_ucodes=0
+
+
+# Show an INFO message
+# $1: message string
+_msg_info() {
+    local _msg="${1}"
+    [[ "${quiet}" == "y" ]] || printf '[%s] INFO: %s\n' "${app_name}" "${_msg}"
+}
+
+# Show a WARNING message
+# $1: message string
+_msg_warning() {
+    local _msg="${1}"
+    printf '[%s] WARNING: %s\n' "${app_name}" "${_msg}" >&2
+}
+
+# Show an ERROR message then exit with status
+# $1: message string
+# $2: exit code number (with 0 does not exit)
+_msg_error() {
+    local _msg="${1}"
+    local _error=${2}
+    printf '[%s] ERROR: %s\n' "${app_name}" "${_msg}" >&2
+    if (( _error > 0 )); then
+        exit "${_error}"
+    fi
+}
+
+# Show help usage, with an exit status.
+# $1: exit status number.
+_usage() {
+    IFS='' read -r -d '' usagetext <<ENDUSAGETEXT || true
+usage: ${app_name} [options] <profile_dir>
+  options:
+     -A <application> Set an application name for the ISO
+                      Default: '${iso_application}'
+     -C <file>        pacman configuration file.
+                      Default: '${pacman_conf}'
+     -D <install_dir> Set an install_dir. All files will be located here.
+                      Default: '${install_dir}'
+                      NOTE: Max 8 characters, use only [a-z0-9]
+     -L <label>       Set the ISO volume label
+                      Default: '${iso_label}'
+     -P <publisher>   Set the ISO publisher
+                      Default: '${iso_publisher}'
+     -c [cert ..]     Provide certificates for codesigning of netboot artifacts as
+                      well as the rootfs artifact.
+                      Multiple files are provided as quoted, space delimited list.
+                      The first file is considered as the signing certificate,
+                      the second as the key and the third as the optional certificate authority.
+     -g <gpg_key>     Set the PGP key ID to be used for signing the rootfs image.
+                      Passed to gpg as the value for --default-key
+     -G <mbox>        Set the PGP signer (must include an email address)
+                      Passed to gpg as the value for --sender
+     -h               This message
+     -m [mode ..]     Build mode(s) to use (valid modes are: 'bootstrap', 'iso' and 'netboot').
+                      Multiple build modes are provided as quoted, space delimited list.
+     -o <out_dir>     Set the output directory
+                      Default: '${out_dir}'
+     -p [package ..]  Package(s) to install.
+                      Multiple packages are provided as quoted, space delimited list.
+     -r               Delete the working directory at the end.
+     -v               Enable verbose output
+     -w <work_dir>    Set the working directory
+                      Default: '${work_dir}'
+
+  profile_dir:        Directory of the archiso profile to build
+ENDUSAGETEXT
+    printf '%s' "${usagetext}"
+    exit "${1}"
+}
+
+# Shows configuration options.
+_show_config() {
+    local build_date
+    printf -v build_date '%(%FT%R%z)T' "${SOURCE_DATE_EPOCH}"
+    _msg_info "${app_name} configuration settings"
+    _msg_info "             Architecture:   ${arch}"
+    _msg_info "        Working directory:   ${work_dir}"
+    _msg_info "   Installation directory:   ${install_dir}"
+    _msg_info "               Build date:   ${build_date}"
+    _msg_info "         Output directory:   ${out_dir}"
+    _msg_info "       Current build mode:   ${buildmode}"
+    _msg_info "              Build modes:   ${buildmodes[*]}"
+    _msg_info "                  GPG key:   ${gpg_key:-None}"
+    _msg_info "               GPG signer:   ${gpg_sender:-None}"
+    _msg_info "Code signing certificates:   ${cert_list[*]:-None}"
+    _msg_info "                  Profile:   ${profile}"
+    _msg_info "Pacman configuration file:   ${pacman_conf}"
+    _msg_info "          Image file name:   ${image_name:-None}"
+    _msg_info "         ISO volume label:   ${iso_label}"
+    _msg_info "            ISO publisher:   ${iso_publisher}"
+    _msg_info "          ISO application:   ${iso_application}"
+    _msg_info "               Boot modes:   ${bootmodes[*]:-None}"
+    _msg_info "            Packages File:   ${buildmode_packages}"
+    _msg_info "                 Packages:   ${buildmode_pkg_list[*]}"
+}
+
+# Cleanup airootfs
+_cleanup_pacstrap_dir() {
+    _msg_info "Cleaning up in pacstrap location..."
+
+    # Delete all files in /boot
+    [[ -d "${pacstrap_dir}/boot" ]] && find "${pacstrap_dir}/boot" -mindepth 1 -delete
+    # Delete pacman database sync cache files (*.tar.gz)
+    [[ -d "${pacstrap_dir}/var/lib/pacman" ]] && find "${pacstrap_dir}/var/lib/pacman" -maxdepth 1 -type f -delete
+    # Delete pacman database sync cache
+    [[ -d "${pacstrap_dir}/var/lib/pacman/sync" ]] && find "${pacstrap_dir}/var/lib/pacman/sync" -delete
+    # Delete pacman package cache
+    [[ -d "${pacstrap_dir}/var/cache/pacman/pkg" ]] && find "${pacstrap_dir}/var/cache/pacman/pkg" -type f -delete
+    # Delete all log files, keeps empty dirs.
+    [[ -d "${pacstrap_dir}/var/log" ]] && find "${pacstrap_dir}/var/log" -type f -delete
+    # Delete all temporary files and dirs
+    [[ -d "${pacstrap_dir}/var/tmp" ]] && find "${pacstrap_dir}/var/tmp" -mindepth 1 -delete
+    # Delete package pacman related files.
+    find "${work_dir}" \( -name '*.pacnew' -o -name '*.pacsave' -o -name '*.pacorig' \) -delete
+    # Create /etc/machine-id with special value 'uninitialized': the final id is
+    # generated on first boot, systemd's first-boot mechanism applies (see machine-id(5))
+    rm -f -- "${pacstrap_dir}/etc/machine-id"
+    printf 'uninitialized\n' >"${pacstrap_dir}/etc/machine-id"
+
+    _msg_info "Done!"
+}
+
+# Create a squashfs image and place it in the ISO 9660 file system.
+# $@: options to pass to mksquashfs
+_run_mksquashfs() {
+    local mksquashfs_options=() image_path="${isofs_dir}/${install_dir}/${arch}/airootfs.sfs"
+    rm -f -- "${image_path}"
+    [[ ! "${quiet}" == "y" ]] || mksquashfs_options+=('-no-progress' '-quiet')
+    mksquashfs "$@" "${image_path}" -noappend "${airootfs_image_tool_options[@]}" "${mksquashfs_options[@]}"
+}
+
+# Create an ext4 image containing the root file system and pack it inside a squashfs image.
+# Save the squashfs image on the ISO 9660 file system.
+_mkairootfs_ext4+squashfs() {
+    local ext4_hash_seed mkfs_ext4_options=()
+    [[ -e "${pacstrap_dir}" ]] || _msg_error "The path '${pacstrap_dir}' does not exist" 1
+
+    _msg_info "Creating ext4 image of 32 GiB and copying '${pacstrap_dir}/' to it..."
+
+    ext4_hash_seed="$(uuidgen --sha1 --namespace 93a870ff-8565-4cf3-a67b-f47299271a96 \
+        --name "${SOURCE_DATE_EPOCH} ext4 hash seed")"
+    mkfs_ext4_options=(
+        '-d' "${pacstrap_dir}"
+        '-O' '^has_journal,^resize_inode'
+        '-E' "lazy_itable_init=0,root_owner=0:0,hash_seed=${ext4_hash_seed}"
+        '-m' '0'
+        '-F'
+        '-U' 'clear'
+    )
+    [[ ! "${quiet}" == "y" ]] || mkfs_ext4_options+=('-q')
+    rm -f -- "${pacstrap_dir}.img"
+    mkfs.ext4 "${mkfs_ext4_options[@]}" -- "${pacstrap_dir}.img" 32G
+    _msg_info "Done!"
+
+    install -d -m 0755 -- "${isofs_dir}/${install_dir}/${arch}"
+    _msg_info "Creating SquashFS image, this may take some time..."
+    _run_mksquashfs "${pacstrap_dir}.img"
+    _msg_info "Done!"
+    rm -- "${pacstrap_dir}.img"
+}
+
+# Create a squashfs image containing the root file system and saves it on the ISO 9660 file system.
+_mkairootfs_squashfs() {
+    [[ -e "${pacstrap_dir}" ]] || _msg_error "The path '${pacstrap_dir}' does not exist" 1
+
+    install -d -m 0755 -- "${isofs_dir}/${install_dir}/${arch}"
+    _msg_info "Creating SquashFS image, this may take some time..."
+    _run_mksquashfs "${pacstrap_dir}"
+}
+
+# Create an EROFS image containing the root file system and saves it on the ISO 9660 file system.
+_mkairootfs_erofs() {
+    local mkfs_erofs_options=()
+    [[ -e "${pacstrap_dir}" ]] || _msg_error "The path '${pacstrap_dir}' does not exist" 1
+
+    install -d -m 0755 -- "${isofs_dir}/${install_dir}/${arch}"
+    local image_path="${isofs_dir}/${install_dir}/${arch}/airootfs.erofs"
+    rm -f -- "${image_path}"
+    [[ ! "${quiet}" == "y" ]] || mkfs_erofs_options+=('--quiet')
+    mkfs_erofs_options+=('-U' '00000000-0000-0000-0000-000000000000' "${airootfs_image_tool_options[@]}")
+    _msg_info "Creating EROFS image, this may take some time..."
+    mkfs.erofs "${mkfs_erofs_options[@]}" -- "${image_path}" "${pacstrap_dir}"
+    _msg_info "Done!"
+}
+
+# Create checksum file for the rootfs image.
+_mkchecksum() {
+    _msg_info "Creating checksum file for self-test..."
+    cd -- "${isofs_dir}/${install_dir}/${arch}"
+    if [[ -e "${isofs_dir}/${install_dir}/${arch}/airootfs.sfs" ]]; then
+        sha512sum airootfs.sfs >airootfs.sha512
+    elif [[ -e "${isofs_dir}/${install_dir}/${arch}/airootfs.erofs" ]]; then
+        sha512sum airootfs.erofs >airootfs.sha512
+    fi
+    cd -- "${OLDPWD}"
+    _msg_info "Done!"
+}
+
+# GPG sign the root file system image.
+_mk_pgp_signature() {
+    local gpg_options=()
+    local airootfs_image_filename="${1}"
+    _msg_info "Signing rootfs image using GPG..."
+
+    rm -f -- "${airootfs_image_filename}.sig"
+    # Add gpg sender option if the value is provided
+    [[ -z "${gpg_sender}" ]] || gpg_options+=('--sender' "${gpg_sender}")
+    # always use the .sig file extension, as that is what mkinitcpio-archiso's hooks expect
+    gpg --batch --no-armor --no-include-key-block --output "${airootfs_image_filename}.sig" --detach-sign \
+        --default-key "${gpg_key}" "${gpg_options[@]}" "${airootfs_image_filename}"
+    _msg_info "Done!"
+}
+
+# Helper function to run functions only one time.
+# $1: function name
+_run_once() {
+    if [[ ! -e "${work_dir}/${run_once_mode}.${1}" ]]; then
+        "$1"
+        touch "${work_dir}/${run_once_mode}.${1}"
+    fi
+}
+
+# Set up custom pacman.conf with custom cache and pacman hook directories.
+_make_pacman_conf() {
+    local _cache_dirs _system_cache_dirs _profile_cache_dirs
+    _system_cache_dirs="$(pacman-conf CacheDir | tr '\n' ' ')"
+    _profile_cache_dirs="$(pacman-conf --config "${pacman_conf}" CacheDir | tr '\n' ' ')"
+
+    # Only use the profile's CacheDir, if it is not the default and not the same as the system cache dir.
+    if [[ "${_profile_cache_dirs}" != "/var/cache/pacman/pkg" ]] \
+        && [[ "${_system_cache_dirs}" != "${_profile_cache_dirs}" ]]; then
+        _cache_dirs="${_profile_cache_dirs}"
+    else
+        _cache_dirs="${_system_cache_dirs}"
+    fi
+
+    _msg_info "Copying custom pacman.conf to work directory..."
+    _msg_info "Using pacman CacheDir: ${_cache_dirs}"
+    # take the profile pacman.conf and strip all settings that would break in chroot when using pacman -r
+    # append CacheDir and HookDir to [options] section
+    # HookDir is *always* set to the airootfs' override directory
+    # see `man 8 pacman` for further info
+    pacman-conf --config "${pacman_conf}" \
+        | sed "/CacheDir/d;/DBPath/d;/HookDir/d;/LogFile/d;/RootDir/d;/\[options\]/a CacheDir = ${_cache_dirs}
+        /\[options\]/a HookDir = ${pacstrap_dir}/etc/pacman.d/hooks/" >"${work_dir}/${buildmode}.pacman.conf"
+}
+
+# Prepare working directory and copy custom root file system files.
+_make_custom_airootfs() {
+    local passwd=()
+    local filename permissions
+
+    install -d -m 0755 -o 0 -g 0 -- "${pacstrap_dir}"
+
+    if [[ -d "${profile}/airootfs" ]]; then
+        _msg_info "Copying custom airootfs files..."
+        cp -af --no-preserve=ownership,mode -- "${profile}/airootfs/." "${pacstrap_dir}"
+        # Set ownership and mode for files and directories
+        for filename in "${!file_permissions[@]}"; do
+            IFS=':' read -ra permissions <<<"${file_permissions["${filename}"]}"
+            # Prevent file path traversal outside of $pacstrap_dir
+            if [[ "$(realpath -q -- "${pacstrap_dir}${filename}")" != "${pacstrap_dir}"* ]]; then
+                _msg_error "Failed to set permissions on '${pacstrap_dir}${filename}'. Outside of valid path." 1
+            # Warn if the file does not exist
+            elif [[ ! -e "${pacstrap_dir}${filename}" ]]; then
+                _msg_warning "Cannot change permissions of '${pacstrap_dir}${filename}'. The file or directory does not exist."
+            else
+                if [[ "${filename: -1}" == "/" ]]; then
+                    chown -fhR -- "${permissions[0]}:${permissions[1]}" "${pacstrap_dir}${filename}"
+                    chmod -fR -- "${permissions[2]}" "${pacstrap_dir}${filename}"
+                else
+                    chown -fh -- "${permissions[0]}:${permissions[1]}" "${pacstrap_dir}${filename}"
+                    chmod -f -- "${permissions[2]}" "${pacstrap_dir}${filename}"
+                fi
+            fi
+        done
+        _msg_info "Done!"
+    fi
+}
+
+# Install desired packages to the root file system
+_make_packages() {
+    _msg_info "Installing packages to '${pacstrap_dir}/'..."
+
+    if [[ -v gpg_publickey ]]; then
+        exec {ARCHISO_GNUPG_FD}<"$gpg_publickey"
+        export ARCHISO_GNUPG_FD
+    fi
+    if [[ -v cert_list[0] ]]; then
+        exec {ARCHISO_TLS_FD}<"${cert_list[0]}"
+        export ARCHISO_TLS_FD
+    fi
+    if [[ -v cert_list[2] ]]; then
+        exec {ARCHISO_TLSCA_FD}<"${cert_list[2]}"
+        export ARCHISO_TLSCA_FD
+    fi
+
+
+    # Unset TMPDIR to work around https://bugs.archlinux.org/task/70580
+    if [[ "${quiet}" = "y" ]]; then
+        env -u TMPDIR pacstrap -C "${work_dir}/${buildmode}.pacman.conf" -c -G -M -- "${pacstrap_dir}" "${buildmode_pkg_list[@]}" &>/dev/null
+    else
+        env -u TMPDIR pacstrap -C "${work_dir}/${buildmode}.pacman.conf" -c -G -M -- "${pacstrap_dir}" "${buildmode_pkg_list[@]}"
+    fi
+
+    if [[ -v cert_list[0] ]]; then
+        exec {ARCHISO_TLS_FD}<&-
+        unset ARCHISO_TLS_FD
+    fi
+    if [[ -v cert_list[2] ]]; then
+        exec {ARCHISO_TLSCA_FD}<&-
+        unset ARCHISO_TLSCA_FD
+    fi
+    if [[ -v gpg_publickey ]]; then
+        exec {ARCHISO_GNUPG_FD}<&-
+        unset ARCHISO_GNUPG_FD
+    fi
+
+    _msg_info "Done! Packages installed successfully."
+}
+
+# Customize installation.
+_make_customize_airootfs() {
+    local passwd=()
+
+    if [[ -e "${profile}/airootfs/etc/passwd" ]]; then
+        _msg_info "Copying /etc/skel/* to user homes..."
+        while IFS=':' read -a passwd -r; do
+            # Only operate on UIDs in range 1000–59999
+            (( passwd[2] >= 1000 && passwd[2] < 60000 )) || continue
+            # Skip invalid home directories
+            [[ "${passwd[5]}" == '/' ]] && continue
+            [[ -z "${passwd[5]}" ]] && continue
+            # Prevent path traversal outside of $pacstrap_dir
+            if [[ "$(realpath -q -- "${pacstrap_dir}${passwd[5]}")" == "${pacstrap_dir}"* ]]; then
+                if [[ ! -d "${pacstrap_dir}${passwd[5]}" ]]; then
+                    install -d -m 0750 -o "${passwd[2]}" -g "${passwd[3]}" -- "${pacstrap_dir}${passwd[5]}"
+                fi
+                cp -dRT --update=none --preserve=mode,timestamps,links -- "${pacstrap_dir}/etc/skel/." "${pacstrap_dir}${passwd[5]}"
+                chmod -f 0750 -- "${pacstrap_dir}${passwd[5]}"
+                chown -hR -- "${passwd[2]}:${passwd[3]}" "${pacstrap_dir}${passwd[5]}"
+            else
+                _msg_error "Failed to set permissions on '${pacstrap_dir}${passwd[5]}'. Outside of valid path." 1
+            fi
+        done <"${profile}/airootfs/etc/passwd"
+        _msg_info "Done!"
+    fi
+
+    if [[ -e "${pacstrap_dir}/root/customize_airootfs.sh" ]]; then
+        _msg_info "Running customize_airootfs.sh in '${pacstrap_dir}' chroot..."
+        _msg_warning "customize_airootfs.sh is deprecated! Support for it will be removed in a future archiso version."
+        chmod -f -- +x "${pacstrap_dir}/root/customize_airootfs.sh"
+        # Unset TMPDIR to work around https://bugs.archlinux.org/task/70580
+        eval -- env -u TMPDIR arch-chroot "${pacstrap_dir}" "/root/customize_airootfs.sh"
+        rm -- "${pacstrap_dir}/root/customize_airootfs.sh"
+        _msg_info "Done! customize_airootfs.sh run successfully."
+    fi
+}
+
+# Set up boot loaders
+_make_bootmodes() {
+    local bootmode
+    for bootmode in "${bootmodes[@]}"; do
+        _run_once "_make_bootmode_${bootmode}"
+    done
+
+    if [[ "${bootmodes[*]}" != *grub* ]]; then
+        _run_once _make_common_grubenv_and_loopbackcfg
+    fi
+}
+
+# Copy kernel and initramfs to ISO 9660
+_make_boot_on_iso9660() {
+    local ucode_image
+    _msg_info "Preparing kernel and initramfs for the ISO 9660 file system..."
+        install -d -m 0755 -- "${isofs_dir}/${install_dir}/boot/${arch}"
+        install -m 0644 -- "${pacstrap_dir}/boot/initramfs-linux.img" "${isofs_dir}/${install_dir}/boot/${arch}/"
+        install -m 0644 -- "${pacstrap_dir}/boot/vmlinuz-linux" "${isofs_dir}/${install_dir}/boot/${arch}/"
+
+    if (( need_external_ucodes )); then
+        for ucode_image in "${ucodes[@]}"; do
+            if [[ -e "${pacstrap_dir}/boot/${ucode_image}" ]]; then
+                install -m 0644 -- "${pacstrap_dir}/boot/${ucode_image}" "${isofs_dir}/${install_dir}/boot/"
+                if [[ -e "${pacstrap_dir}/usr/share/licenses/${ucode_image%.*}/" ]]; then
+                    install -d -m 0755 -- "${isofs_dir}/${install_dir}/boot/licenses/${ucode_image%.*}/"
+                    install -m 0644 -- "${pacstrap_dir}/usr/share/licenses/${ucode_image%.*}/"* \
+                        "${isofs_dir}/${install_dir}/boot/licenses/${ucode_image%.*}/"
+                fi
+            fi
+        done
+    fi
+    _msg_info "Done!"
+}
+
+# Prepare syslinux for booting from MBR (isohybrid)
+_make_bootmode_bios.syslinux.mbr() {
+    _msg_info "Setting up SYSLINUX for BIOS booting from a disk..."
+    install -d -m 0755 -- "${isofs_dir}/boot/syslinux"
+    for _cfg in "${profile}/syslinux/"*.cfg; do
+        sed "s|%ARCHISO_LABEL%|${iso_label}|g;
+             s|%ARCHISO_UUID%|${iso_uuid}|g;
+             s|%INSTALL_DIR%|${install_dir}|g;
+             s|%ARCH%|${arch}|g" \
+            "${_cfg}" >"${isofs_dir}/boot/syslinux/${_cfg##*/}"
+    done
+    if [[ -e "${profile}/syslinux/splash.png" ]]; then
+        install -m 0644 -- "${profile}/syslinux/splash.png" "${isofs_dir}/boot/syslinux/"
+    fi
+    install -m 0644 -- "${pacstrap_dir}/usr/lib/syslinux/bios/"*.c32 "${isofs_dir}/boot/syslinux/"
+    install -m 0644 -- "${pacstrap_dir}/usr/lib/syslinux/bios/lpxelinux.0" "${isofs_dir}/boot/syslinux/"
+    install -m 0644 -- "${pacstrap_dir}/usr/lib/syslinux/bios/memdisk" "${isofs_dir}/boot/syslinux/"
+
+    _run_once _make_boot_on_iso9660
+
+    if [[ -e "${isofs_dir}/boot/syslinux/hdt.c32" ]]; then
+        install -d -m 0755 -- "${isofs_dir}/boot/syslinux/hdt"
+        if [[ -e "${pacstrap_dir}/usr/share/hwdata/pci.ids" ]]; then
+            gzip -cn9 "${pacstrap_dir}/usr/share/hwdata/pci.ids" > \
+                "${isofs_dir}/boot/syslinux/hdt/pciids.gz"
+        fi
+        find "${pacstrap_dir}/usr/lib/modules" -name 'modules.alias' -print -exec gzip -cn9 '{}' ';' -quit > \
+            "${isofs_dir}/boot/syslinux/hdt/modalias.gz"
+    fi
+
+    # Add other aditional/extra files to ${install_dir}/boot/
+    if [[ -e "${pacstrap_dir}/boot/memtest86+/memtest.bin" ]]; then
+        install -d -m 0755 -- "${isofs_dir}/boot/memtest86+/"
+        # rename for PXE: https://wiki.archlinux.org/title/Syslinux#Using_memtest
+        install -m 0644 -- "${pacstrap_dir}/boot/memtest86+/memtest.bin" "${isofs_dir}/boot/memtest86+/memtest"
+        install -m 0644 -- "${pacstrap_dir}/usr/share/licenses/spdx/GPL-2.0-only.txt" "${isofs_dir}/boot/memtest86+/LICENSE"
+    fi
+    _msg_info "Done! SYSLINUX set up for BIOS booting from a disk successfully."
+}
+
+# Prepare syslinux for El-Torito booting
+_make_bootmode_bios.syslinux.eltorito() {
+    _msg_info "Setting up SYSLINUX for BIOS booting from an optical disc..."
+    install -d -m 0755 -- "${isofs_dir}/boot/syslinux"
+    install -m 0644 -- "${pacstrap_dir}/usr/lib/syslinux/bios/isolinux.bin" "${isofs_dir}/boot/syslinux/"
+    install -m 0644 -- "${pacstrap_dir}/usr/lib/syslinux/bios/isohdpfx.bin" "${isofs_dir}/boot/syslinux/"
+
+    # ISOLINUX and SYSLINUX installation is shared
+    _run_once _make_bootmode_bios.syslinux.mbr
+
+    _msg_info "Done! SYSLINUX set up for BIOS booting from an optical disc successfully."
+}
+
+# Copy kernel and initramfs to FAT image
+_make_boot_on_fat() {
+    local ucode_image all_ucode_images=()
+    _msg_info "Preparing kernel and initramfs for the FAT file system..."
+    mmd -i "${efibootimg}" \
+        "::/${install_dir}" "::/${install_dir}/boot" "::/${install_dir}/boot/${arch}"
+    mcopy -i "${efibootimg}" "${pacstrap_dir}/boot/vmlinuz-"* \
+        "${pacstrap_dir}/boot/initramfs-"*".img" "::/${install_dir}/boot/${arch}/"
+    if (( need_external_ucodes )); then
+        for ucode_image in "${ucodes[@]}"; do
+            if [[ -e "${pacstrap_dir}/boot/${ucode_image}" ]]; then
+                all_ucode_images+=("${pacstrap_dir}/boot/${ucode_image}")
+            fi
+        done
+        if (( ${#all_ucode_images[@]} )); then
+            mcopy -i "${efibootimg}" "${all_ucode_images[@]}" "::/${install_dir}/boot/"
+        fi
+    fi
+    _msg_info "Done!"
+}
+
+# Create a FAT image (efiboot.img) which will serve as the EFI system partition
+# $1: image size in bytes
+_make_efibootimg() {
+    local imgsize_kib="0"
+    local imgsize_bytes=${1}
+    local mkfs_fat_opts=(-C -n ARCHISO_EFI)
+
+    # Convert from bytes to KiB and round up to the next full MiB with an additional 8 MiB for reserved sectors, file
+    # and directory entries and to allow adding custom files when repacking the ISO.
+    imgsize_kib="$(
+        awk 'function ceil(x){return int(x)+(x>int(x))}
+            function byte_to_kib(x){return x/1024}
+            function mib_to_kib(x){return x*1024}
+            END {print mib_to_kib(ceil((byte_to_kib($1)+8192)/1024))}' <<<"${imgsize_bytes}"
+    )"
+
+    # Use FAT32 as early as possible. mkfs.fat selects FAT32 if the size ≥ 512 MiB, but a FAT32 file system can already
+    # be created at 36 MiB size (assuming 512 byte logical sector size).
+    if (( imgsize_kib >= 36864 )); then
+        mkfs_fat_opts+=(-F 32)
+    fi
+
+    # The FAT image must be created with mkfs.fat not mformat, as some systems have issues with mformat made images:
+    # https://lists.gnu.org/archive/html/grub-devel/2019-04/msg00099.html
+    rm -f -- "${efibootimg}"
+    _msg_info "Creating FAT image of size: ${imgsize_kib} KiB..."
+    if [[ "${quiet}" == "y" ]]; then
+        # mkfs.fat does not have a -q/--quiet option, so redirect stdout to /dev/null instead
+        # https://github.com/dosfstools/dosfstools/issues/103
+        mkfs.fat "${mkfs_fat_opts[@]}" "${efibootimg}" "${imgsize_kib}" >/dev/null
+    else
+        mkfs.fat "${mkfs_fat_opts[@]}" "${efibootimg}" "${imgsize_kib}"
+    fi
+
+    # Create the default/fallback boot path in which a boot loaders will be placed later.
+    mmd -i "${efibootimg}" ::/EFI ::/EFI/BOOT
+}
+
+# Check if initramfs files contain microcode update files
+_check_if_initramfs_has_ucode() {
+    local initrd
+
+    for initrd in $(compgen -G "${pacstrap_dir}"'/boot/initramfs-*.img'); do
+        if  [[ "${arch}" != "loong64" ]]; then
+            if ! bsdtar -tf "$initrd" 'early_cpio' 'kernel/x86/microcode/*.bin' &>/dev/null; then
+                need_external_ucodes=1
+                _msg_info "Initramfs file does not contain microcode update files. External microcode initramfs images will be copied."
+                return
+            fi
+        fi
+    done
+}
+
+# Copy GRUB files to ISO 9660 which is used by both IA32 UEFI and x64 UEFI
+_make_common_bootmode_grub_copy_to_isofs() {
+    local files_to_copy=()
+
+    files_to_copy+=("${work_dir}/grub/"*)
+    if compgen -G "${profile}/grub/!(*.cfg)" &>/dev/null; then
+        files_to_copy+=("${profile}/grub/"!(*.cfg))
+    fi
+    install -d -m 0755 -- "${isofs_dir}/boot/grub"
+    cp -r --remove-destination -- "${files_to_copy[@]}" "${isofs_dir}/boot/grub/"
+}
+
+# Prepare GRUB configuration files
+_make_common_bootmode_grub_cfg() {
+    local _cfg
+
+    install -d -- "${work_dir}/grub"
+
+    # Fill GRUB configuration files
+    for _cfg in "${profile}/grub/"*'.cfg'; do
+        sed "s|%ARCHISO_LABEL%|${iso_label}|g;
+             s|%ARCHISO_UUID%|${iso_uuid}|g;
+             s|%INSTALL_DIR%|${install_dir}|g;
+             s|%ARCH%|${arch}|g;
+             s|%ARCHISO_SEARCH_FILENAME%|${search_filename}|g" \
+            "${_cfg}" >"${work_dir}/grub/${_cfg##*/}"
+    done
+
+    # Prepare grub.cfg that will be embedded inside the GRUB binaries
+    IFS='' read -r -d '' grubembedcfg <<'EOF' || true
+if ! [ -d "$cmdpath" ]; then
+    # On some firmware, GRUB has a wrong cmdpath when booted from an optical disc. During El Torito boot, GRUB is
+    # launched from a case-insensitive FAT-formatted EFI system partition, but it seemingly cannot access that partition
+    # and sets cmdpath to the whole cd# device which has case-sensitive ISO 9660 + Rock Ridge + Joliet file systems.
+    # See https://gitlab.archlinux.org/archlinux/archiso/-/issues/183 and https://savannah.gnu.org/bugs/?62886
+    if regexp --set=1:archiso_bootdevice '^\(([^)]+)\)\/?[Ee][Ff][Ii]\/[Bb][Oo][Oo][Tt]\/?$' "${cmdpath}"; then
+        set cmdpath="(${archiso_bootdevice})/EFI/BOOT"
+        set ARCHISO_HINT="${archiso_bootdevice}"
+    fi
+fi
+
+# Prepare a hint for the search command using the device in cmdpath
+if [ -z "${ARCHISO_HINT}" ]; then
+    regexp --set=1:ARCHISO_HINT '^\(([^)]+)\)' "${cmdpath}"
+fi
+
+# Search for the ISO volume
+if search --no-floppy --set=archiso_device --file '%ARCHISO_SEARCH_FILENAME%' --hint "${ARCHISO_HINT}"; then
+    set ARCHISO_HINT="${archiso_device}"
+    if probe --set ARCHISO_UUID --fs-uuid "${ARCHISO_HINT}"; then
+        export ARCHISO_UUID
+    fi
+else
+    echo "Could not find a volume with a '%ARCHISO_SEARCH_FILENAME%' file on it!"
+fi
+
+# Load grub.cfg
+if [ "${ARCHISO_HINT}" == 'memdisk' -o -z "${ARCHISO_HINT}" ]; then
+    echo 'Could not find the ISO volume!'
+elif [ -e "(${ARCHISO_HINT})/boot/grub/grub.cfg" ]; then
+    export ARCHISO_HINT
+    set root="${ARCHISO_HINT}"
+    configfile "(${ARCHISO_HINT})/boot/grub/grub.cfg"
+else
+    echo "File '(${ARCHISO_HINT})/boot/grub/grub.cfg' not found!"
+fi
+EOF
+    grubembedcfg="${grubembedcfg//'%ARCHISO_SEARCH_FILENAME%'/"${search_filename}"}"
+    printf '%s\n' "$grubembedcfg" >"${work_dir}/grub-embed.cfg"
+
+    # Write grubenv
+    printf '%.1024s' \
+        "$(printf '# GRUB Environment Block\nNAME=%s\nVERSION=%s\nARCHISO_LABEL=%s\nINSTALL_DIR=%s\nARCH=%s\nARCHISO_SEARCH_FILENAME=%s\n%s' \
+            "${iso_name}" \
+            "${iso_version}" \
+            "${iso_label}" \
+            "${install_dir}" \
+            "${arch}" \
+            "${search_filename}" \
+            "$(printf '%0.1s' "#"{1..1024})")" \
+        >"${work_dir}/grub/grubenv"
+}
+
+# Create GRUB specific configuration files when GRUB is not used as a boot loader
+_make_common_grubenv_and_loopbackcfg() {
+
+    install -d -m 0755 -- "${isofs_dir}/boot/grub"
+    # Write grubenv
+    printf '%.1024s' \
+        "$(printf '# GRUB Environment Block\nNAME=%s\nVERSION=%s\nARCHISO_LABEL=%s\nINSTALL_DIR=%s\nARCH=%s\nARCHISO_SEARCH_FILENAME=%s\n%s' \
+            "${iso_name}" \
+            "${iso_version}" \
+            "${iso_label}" \
+            "${install_dir}" \
+            "${arch}" \
+            "${search_filename}" \
+            "$(printf '%0.1s' "#"{1..1024})")" \
+        >"${isofs_dir}/boot/grub/grubenv"
+
+    # Copy loopback.cfg to /boot/grub/ on ISO 9660
+    if [[ -e "${profile}/grub/loopback.cfg" ]]; then
+        sed "s|%ARCHISO_LABEL%|${iso_label}|g;
+             s|%ARCHISO_UUID%|${iso_uuid}|g;
+             s|%INSTALL_DIR%|${install_dir}|g;
+             s|%ARCH%|${arch}|g;
+             s|%ARCHISO_SEARCH_FILENAME%|${search_filename}|g" \
+            "${profile}/grub/loopback.cfg" >"${isofs_dir}/boot/grub/loopback.cfg"
+    fi
+}
+
+_make_bootmode_uefi-ia32.grub.esp() {
+    local grubmodules=()
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_grub_cfg
+
+    # Create EFI binary
+    # Module list from https://bugs.archlinux.org/task/71382#comment202911
+    grubmodules=(all_video at_keyboard boot btrfs cat chain configfile echo efifwsetup efinet exfat ext2 f2fs fat font \
+                 gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg keylayouts linux loadenv loopback lsefi lsefimmap \
+                 minicmd normal ntfs ntfscomp part_apple part_gpt part_msdos png read reboot regexp search \
+                 search_fs_file search_fs_uuid search_label serial sleep tpm udf usb usbserial_common usbserial_ftdi \
+                 usbserial_pl2303 usbserial_usbdebug video xfs zstd)
+    grub-mkstandalone -O i386-efi \
+        --modules="${grubmodules[*]}" \
+        --locales="en@quot" \
+        --themes="" \
+        --sbat=/usr/share/grub/sbat.csv \
+        --disable-shim-lock \
+        -o "${work_dir}/BOOTIA32.EFI" "boot/grub/grub.cfg=${work_dir}/grub-embed.cfg"
+    # Add GRUB to the list of files used to calculate the required FAT image size.
+    efiboot_files+=("${work_dir}/BOOTIA32.EFI"
+                    "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi")
+
+    if [[ " ${bootmodes[*]} " =~ uefi-x64.systemd-boot.esp ]]; then
+        # TODO: Remove this branch.
+        _run_once _make_bootmode_uefi-x64.systemd-boot.esp
+    elif [[ " ${bootmodes[*]} " =~ uefi-x64.grub.esp ]]; then
+        _run_once _make_bootmode_uefi-x64.grub.esp
+    else
+        efiboot_imgsize="$(du -bcs -- "${efiboot_files[@]}" 2>/dev/null | awk 'END { print $1 }')"
+        # Create a FAT image for the EFI system partition
+        _make_efibootimg "$efiboot_imgsize"
+    fi
+
+    # Copy GRUB EFI binary to the default/fallback boot path
+    mcopy -i "${efibootimg}" "${work_dir}/BOOTIA32.EFI" ::/EFI/BOOT/BOOTIA32.EFI
+
+    # Copy GRUB files
+    _run_once _make_common_bootmode_grub_copy_to_isofs
+
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" ]]; then
+        mcopy -i "${efibootimg}" "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" ::/shellia32.efi
+    fi
+
+    _msg_info "Done! GRUB set up for UEFI booting successfully."
+}
+
+# Prepare GRUB for El Torito booting
+_make_bootmode_uefi-ia32.grub.eltorito() {
+    # El Torito UEFI boot requires an image containing the EFI system partition.
+    # uefi-ia32.grub.eltorito has the same requirements as uefi-ia32.grub.esp
+    _run_once _make_bootmode_uefi-ia32.grub.esp
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_grub_cfg
+
+    # Additionally set up systemd-boot in ISO 9660. This allows creating a medium for the live environment by using
+    # manual partitioning and simply copying the ISO 9660 file system contents.
+    # This is not related to El Torito booting and no firmware uses these files.
+    _msg_info "Preparing an /EFI directory for the ISO 9660 file system..."
+    install -d -m 0755 -- "${isofs_dir}/EFI/BOOT"
+
+    # Copy GRUB EFI binary to the default/fallback boot path
+    install -m 0644 -- "${work_dir}/BOOTIA32.EFI" "${isofs_dir}/EFI/BOOT/BOOTIA32.EFI"
+
+    # Copy GRUB configuration files
+    _run_once _make_common_bootmode_grub_copy_to_isofs
+
+    # edk2-shell based UEFI shell
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" ]]; then
+        install -m 0644 -- "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" "${isofs_dir}/shellia32.efi"
+    fi
+
+    _msg_info "Done!"
+}
+
+_make_bootmode_uefi-loong64.grub.esp() {
+    local grubmodules=()
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_grub_cfg
+
+    # Create EFI binary
+    # Module list from https://bugs.archlinux.org/task/71382#comment202911
+    grubmodules=(acpi all_video boot btrfs cat chain configfile echo efifwsetup efinet exfat ext2 f2fs fat font \
+                 gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg linux loadenv loopback lsefi lsefimmap \
+                 minicmd normal ntfs ntfscomp part_apple part_gpt part_msdos png read reboot regexp search \
+                 search_fs_file search_fs_uuid search_label serial sleep tpm udf \
+                  video xfs zstd)
+    grub-mkstandalone -O loongarch64-efi \
+        --modules="${grubmodules[*]}" \
+        --locales="en@quot" \
+        --themes="" \
+        --sbat=/usr/share/grub/sbat.csv \
+        --disable-shim-lock \
+        -o "${work_dir}/BOOTLOONGARCH64.EFI" "boot/grub/grub.cfg=${work_dir}/grub-embed.cfg"
+    # Add GRUB to the list of files used to calculate the required FAT image size.
+    efiboot_files+=("${work_dir}/BOOTLOONGARCH64.EFI"
+                    "${pacstrap_dir}/usr/share/edk2-shell/loongarch64/Shell_Full.efi")
+
+    efiboot_imgsize="$(du -bcs -- "${efiboot_files[@]}" 2>/dev/null | awk 'END { print $1 }')"
+
+    # Create a FAT image for the EFI system partition
+    _make_efibootimg "$efiboot_imgsize"
+
+    # Copy GRUB EFI binary to the default/fallback boot path
+    mcopy -i "${efibootimg}" "${work_dir}/BOOTLOONGARCH64.EFI" ::/EFI/BOOT/BOOTLOONGARCH64.EFI
+
+    # Copy GRUB files
+    _run_once _make_common_bootmode_grub_copy_to_isofs
+
+    _run_once _make_boot_on_iso9660
+
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/loongarch64/Shell_Full.efi" ]]; then
+        mcopy -i "${efibootimg}" "${pacstrap_dir}/usr/share/edk2-shell/loongarch64/Shell_Full.efi" ::/shellloongarch64.efi
+    fi
+
+    # Add other aditional/extra files to ${install_dir}/boot/
+    if [[ -e "${pacstrap_dir}/boot/memtest86+/memtest.efi" ]]; then
+        install -d -m 0755 -- "${isofs_dir}/boot/memtest86+/"
+        install -m 0644 -- "${pacstrap_dir}/boot/memtest86+/memtest.efi" "${isofs_dir}/boot/memtest86+/memtest.efi"
+        install -m 0644 -- "${pacstrap_dir}/usr/share/licenses/spdx/GPL-2.0-only.txt" "${isofs_dir}/boot/memtest86+/LICENSE"
+    fi
+
+    _msg_info "Done! GRUB set up for UEFI booting successfully."
+}
+
+# Prepare GRUB for El Torito booting
+_make_bootmode_uefi-loong64.grub.eltorito() {
+    # El Torito UEFI boot requires an image containing the EFI system partition.
+    # uefi-x64.grub.eltorito has the same requirements as uefi-x64.grub.esp
+    _run_once _make_bootmode_uefi-loong64.grub.esp
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_grub_cfg
+
+    # Additionally set up systemd-boot in ISO 9660. This allows creating a medium for the live environment by using
+    # manual partitioning and simply copying the ISO 9660 file system contents.
+    # This is not related to El Torito booting and no firmware uses these files.
+    _msg_info "Preparing an /EFI directory for the ISO 9660 file system..."
+    install -d -m 0755 -- "${isofs_dir}/EFI/BOOT"
+
+    # Copy GRUB EFI binary to the default/fallback boot path
+    install -m 0644 -- "${work_dir}/BOOTLOONGARCH64.EFI" "${isofs_dir}/EFI/BOOT/BOOTLOONGARCH64.EFI"
+
+    # Copy GRUB files
+    _run_once _make_common_bootmode_grub_copy_to_isofs
+
+    # edk2-shell based UEFI shell
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/loongarch64/Shell_Full.efi" ]]; then
+        install -m 0644 -- "${pacstrap_dir}/usr/share/edk2-shell/loongarch64/Shell_Full.efi" "${isofs_dir}/shellloongarch64.efi"
+    fi
+
+    _msg_info "Done!"
+}
+
+_make_bootmode_uefi-x64.grub.esp() {
+    local grubmodules=()
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_grub_cfg
+
+    # Create EFI binary
+    # Module list from https://bugs.archlinux.org/task/71382#comment202911
+    grubmodules=(all_video at_keyboard boot btrfs cat chain configfile echo efifwsetup efinet exfat ext2 f2fs fat font \
+                 gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg keylayouts linux loadenv loopback lsefi lsefimmap \
+                 minicmd normal ntfs ntfscomp part_apple part_gpt part_msdos png read reboot regexp search \
+                 search_fs_file search_fs_uuid search_label serial sleep tpm udf usb usbserial_common usbserial_ftdi \
+                 usbserial_pl2303 usbserial_usbdebug video xfs zstd)
+    grub-mkstandalone -O x86_64-efi \
+        --modules="${grubmodules[*]}" \
+        --locales="en@quot" \
+        --themes="" \
+        --sbat=/usr/share/grub/sbat.csv \
+        --disable-shim-lock \
+        -o "${work_dir}/BOOTx64.EFI" "boot/grub/grub.cfg=${work_dir}/grub-embed.cfg"
+    # Add GRUB to the list of files used to calculate the required FAT image size.
+    efiboot_files+=("${work_dir}/BOOTx64.EFI"
+                    "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi")
+
+    efiboot_imgsize="$(du -bcs -- "${efiboot_files[@]}" 2>/dev/null | awk 'END { print $1 }')"
+
+    # Create a FAT image for the EFI system partition
+    _make_efibootimg "$efiboot_imgsize"
+
+    # Copy GRUB EFI binary to the default/fallback boot path
+    mcopy -i "${efibootimg}" "${work_dir}/BOOTx64.EFI" ::/EFI/BOOT/BOOTx64.EFI
+
+    # Copy GRUB files
+    _run_once _make_common_bootmode_grub_copy_to_isofs
+
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" ]]; then
+        mcopy -i "${efibootimg}" "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" ::/shellx64.efi
+    fi
+
+    # Add other aditional/extra files to ${install_dir}/boot/
+    if [[ -e "${pacstrap_dir}/boot/memtest86+/memtest.efi" ]]; then
+        install -d -m 0755 -- "${isofs_dir}/boot/memtest86+/"
+        install -m 0644 -- "${pacstrap_dir}/boot/memtest86+/memtest.efi" "${isofs_dir}/boot/memtest86+/memtest.efi"
+        install -m 0644 -- "${pacstrap_dir}/usr/share/licenses/spdx/GPL-2.0-only.txt" "${isofs_dir}/boot/memtest86+/LICENSE"
+    fi
+
+    _msg_info "Done! GRUB set up for UEFI booting successfully."
+}
+
+# Prepare GRUB for El Torito booting
+_make_bootmode_uefi-x64.grub.eltorito() {
+    # El Torito UEFI boot requires an image containing the EFI system partition.
+    # uefi-x64.grub.eltorito has the same requirements as uefi-x64.grub.esp
+    _run_once _make_bootmode_uefi-x64.grub.esp
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_grub_cfg
+
+    # Additionally set up systemd-boot in ISO 9660. This allows creating a medium for the live environment by using
+    # manual partitioning and simply copying the ISO 9660 file system contents.
+    # This is not related to El Torito booting and no firmware uses these files.
+    _msg_info "Preparing an /EFI directory for the ISO 9660 file system..."
+    install -d -m 0755 -- "${isofs_dir}/EFI/BOOT"
+
+    # Copy GRUB EFI binary to the default/fallback boot path
+    install -m 0644 -- "${work_dir}/BOOTx64.EFI" "${isofs_dir}/EFI/BOOT/BOOTx64.EFI"
+
+    # Copy GRUB files
+    _run_once _make_common_bootmode_grub_copy_to_isofs
+
+    # edk2-shell based UEFI shell
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" ]]; then
+        install -m 0644 -- "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" "${isofs_dir}/shellx64.efi"
+    fi
+
+    _msg_info "Done!"
+}
+
+_make_common_bootmode_systemd-boot() {
+    local _file efiboot_imgsize
+    local _available_ucodes=()
+
+    if (( need_external_ucodes )); then
+        for _file in "${ucodes[@]}"; do
+            if [[ -e "${pacstrap_dir}/boot/${_file}" ]]; then
+                _available_ucodes+=("${pacstrap_dir}/boot/${_file}")
+            fi
+        done
+    fi
+    # Calculate the required FAT image size in bytes
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.esp ' || " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.eltorito ' ]]; then
+        efiboot_files+=("${pacstrap_dir}/usr/lib/systemd/boot/efi/systemd-bootx64.efi"
+                        "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi"
+                        "${pacstrap_dir}/boot/memtest86+/memtest.efi"
+                        "${pacstrap_dir}/usr/share/licenses/spdx/GPL-2.0-only.txt")
+    fi
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-ia32.systemd-boot.esp ' || " ${bootmodes[*]} " =~ ' uefi-ia32.systemd-boot.eltorito ' ]]; then
+        efiboot_files+=("${pacstrap_dir}/usr/lib/systemd/boot/efi/systemd-bootia32.efi"
+                        "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi")
+    fi
+    if [[ " ${bootmodes[*]} " =~ ' uefi-loong64.systemd-boot.esp ' || " ${bootmodes[*]} " =~ ' uefi-loong64.systemd-boot.eltorito ' ]]; then
+        efiboot_files+=("${pacstrap_dir}/usr/lib/systemd/boot/efi/systemd-bootloongarch64.efi"
+                        "${pacstrap_dir}/usr/share/edk2-shell/loongarch64/Shell_Full.efi"
+                        "${pacstrap_dir}/boot/memtest86+/memtest.efi"
+                        "${pacstrap_dir}/usr/share/licenses/spdx/GPL-2.0-only.txt")
+    fi
+
+    efiboot_files+=("${work_dir}/loader/"
+                    "${pacstrap_dir}/boot/vmlinuz-"*""
+                    "${pacstrap_dir}/boot/initramfs-"*".img"
+                    "${_available_ucodes[@]}")
+    efiboot_imgsize="$(du -bcs -- "${efiboot_files[@]}" 2>/dev/null | awk 'END { print $1 }')"
+    # Create a FAT image for the EFI system partition
+    _make_efibootimg "$efiboot_imgsize"
+}
+
+_make_common_bootmode_systemd-boot_conf() {
+    local _conf
+
+    install -d -m 0755 -- "${work_dir}/loader" "${work_dir}/loader/entries"
+
+    install -m 0644 -- "${profile}/efiboot/loader/loader.conf" "${work_dir}/loader"
+    for _conf in "${profile}/efiboot/loader/entries/"*".conf"; do
+        sed "s|%ARCHISO_LABEL%|${iso_label}|g;
+             s|%ARCHISO_UUID%|${iso_uuid}|g;
+             s|%INSTALL_DIR%|${install_dir}|g;
+             s|%ARCH%|${arch}|g" \
+            "${_conf}" >"${work_dir}/loader/entries/${_conf##*/}"
+    done
+}
+
+# Copy systemd-boot configuration files to ISO 9660
+_make_common_bootmode_systemd-boot_conf.isofs() {
+    cp -r --remove-destination -- "${work_dir}/loader" "${isofs_dir}/"
+}
+
+# Copy systemd-boot configuration files to FAT image
+_make_common_bootmode_systemd-boot_conf.esp() {
+    mcopy -i "${efibootimg}" -s "${work_dir}/loader" ::/
+}
+
+# Prepare systemd-boot for booting when written to a disk (isohybrid)
+_make_bootmode_uefi-x64.systemd-boot.esp() {
+    _msg_info "Setting up systemd-boot for x64 UEFI booting..."
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf
+
+    # Prepare a FAT image for the EFI system partition
+    _run_once _make_common_bootmode_systemd-boot
+
+    # Copy systemd-boot EFI binary to the default/fallback boot path
+    mcopy -i "${efibootimg}" \
+        "${pacstrap_dir}/usr/lib/systemd/boot/efi/systemd-bootx64.efi" ::/EFI/BOOT/BOOTx64.EFI
+
+    # Copy systemd-boot configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf.esp
+
+    # shellx64.efi is picked up automatically when on /
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" ]]; then
+        mcopy -i "${efibootimg}" \
+            "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" ::/shellx64.efi
+    fi
+
+    # Copy Memtest86+
+    if [[ -e "${pacstrap_dir}/boot/memtest86+/memtest.efi" ]]; then
+        mmd -i "${efibootimg}" ::/boot ::/boot/memtest86+
+        mcopy -i "${efibootimg}" \
+            "${pacstrap_dir}/boot/memtest86+/memtest.efi" ::/boot/memtest86+/
+        mcopy -i "${efibootimg}" \
+            "${pacstrap_dir}/usr/share/licenses/spdx/GPL-2.0-only.txt" ::/boot/memtest86+/LICENSE
+    fi
+
+    # Copy kernel and initramfs to FAT image.
+    # systemd-boot can only access files from the EFI system partition it was launched from.
+    _run_once _make_boot_on_fat
+
+    _msg_info "Done! systemd-boot set up for x64 UEFI booting successfully."
+}
+
+# Prepare systemd-boot for El Torito booting
+_make_bootmode_uefi-x64.systemd-boot.eltorito() {
+    # Prepare configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf
+
+    # El Torito UEFI boot requires an image containing the EFI system partition.
+    # uefi-x64.systemd-boot.eltorito has the same requirements as uefi-x64.systemd-boot.esp
+    _run_once _make_bootmode_uefi-x64.systemd-boot.esp
+
+    # Additionally set up systemd-boot in ISO 9660. This allows creating a medium for the live environment by using
+    # manual partitioning and simply copying the ISO 9660 file system contents.
+    # This is not related to El Torito booting and no firmware uses these files.
+    _msg_info "Preparing an /EFI directory for the ISO 9660 file system..."
+    install -d -m 0755 -- "${isofs_dir}/EFI/BOOT"
+
+    # Copy systemd-boot EFI binary to the default/fallback boot path
+    install -m 0644 -- "${pacstrap_dir}/usr/lib/systemd/boot/efi/systemd-bootx64.efi" \
+        "${isofs_dir}/EFI/BOOT/BOOTx64.EFI"
+
+    # Copy systemd-boot configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf.isofs
+
+    # edk2-shell based UEFI shell
+    # shellx64.efi is picked up automatically when on /
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" ]]; then
+        install -m 0644 -- "${pacstrap_dir}/usr/share/edk2-shell/x64/Shell_Full.efi" "${isofs_dir}/shellx64.efi"
+    fi
+
+    # Copy Memtest86+
+    if [[ -e "${pacstrap_dir}/boot/memtest86+/memtest.efi" ]]; then
+        install -d -m 0755 -- "${isofs_dir}/boot/memtest86+/"
+        install -m 0644 -- "${pacstrap_dir}/boot/memtest86+/memtest.efi" "${isofs_dir}/boot/memtest86+/memtest.efi"
+        install -m 0644 -- "${pacstrap_dir}/usr/share/licenses/spdx/GPL-2.0-only.txt" "${isofs_dir}/boot/memtest86+/LICENSE"
+    fi
+
+    _msg_info "Done!"
+}
+
+
+_make_bootmode_uefi-ia32.systemd-boot.esp() {
+    _msg_info "Setting up systemd-boot for IA32 UEFI booting..."
+
+    # Prepare configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf
+
+    # Prepare a FAT image for the EFI system partition
+    _run_once _make_common_bootmode_systemd-boot
+
+    # Copy systemd-boot EFI binary to the default/fallback boot path
+    mcopy -i "${efibootimg}" \
+        "${pacstrap_dir}/usr/lib/systemd/boot/efi/systemd-bootia32.efi" ::/EFI/BOOT/BOOTIA32.EFI
+
+    # Copy systemd-boot configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf.esp
+
+    # shellia32.efi is picked up automatically when on /
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" ]]; then
+        mcopy -i "${efibootimg}" \
+            "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" ::/shellia32.efi
+    fi
+
+    # Copy kernel and initramfs to FAT image.
+    # systemd-boot can only access files from the EFI system partition it was launched from.
+    _run_once _make_boot_on_fat
+
+    _msg_info "Done! systemd-boot set up for IA32 UEFI booting successfully."
+}
+
+_make_bootmode_uefi-ia32.systemd-boot.eltorito() {
+    # Prepare configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf
+
+    # El Torito UEFI boot requires an image containing the EFI system partition.
+    # uefi-ia32.systemd-boot.eltorito has the same requirements as uefi-ia32.systemd-boot.esp
+    _run_once _make_bootmode_uefi-ia32.systemd-boot.esp
+
+    # Additionally set up systemd-boot in ISO 9660. This allows creating a medium for the live environment by using
+    # manual partitioning and simply copying the ISO 9660 file system contents.
+    # This is not related to El Torito booting and no firmware uses these files.
+    _msg_info "Preparing an /EFI directory for the ISO 9660 file system..."
+    install -d -m 0755 -- "${isofs_dir}/EFI/BOOT"
+
+    # Copy systemd-boot EFI binary to the default/fallback boot path
+    install -m 0644 -- "${pacstrap_dir}/usr/lib/systemd/boot/efi/systemd-bootia32.efi" \
+        "${isofs_dir}/EFI/BOOT/BOOTIA32.EFI"
+
+    # Copy systemd-boot configuration files
+    _run_once _make_common_bootmode_systemd-boot_conf.isofs
+
+    # edk2-shell based UEFI shell
+    # shellia32.efi is picked up automatically when on /
+    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" ]]; then
+        install -m 0644 -- "${pacstrap_dir}/usr/share/edk2-shell/ia32/Shell_Full.efi" "${isofs_dir}/shellia32.efi"
+    fi
+
+    _msg_info "Done!"
+}
+
+_validate_requirements_bootmode_bios.syslinux.mbr() {
+    # bios.syslinux.mbr requires bios.syslinux.eltorito
+    # shellcheck disable=SC2076
+    if [[ ! " ${bootmodes[*]} " =~ ' bios.syslinux.eltorito ' ]]; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Using 'bios.syslinux.mbr' boot mode without 'bios.syslinux.eltorito' is not supported." 0
+    fi
+
+    # Check if the syslinux package is in the package list
+    # shellcheck disable=SC2076
+    if [[ ! " ${pkg_list[*]} " =~ ' syslinux ' ]]; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': The 'syslinux' package is missing from the package list!" 0
+    fi
+
+    # Check if syslinux configuration files exist
+    if [[ ! -d "${profile}/syslinux" ]]; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': The '${profile}/syslinux' directory is missing!" 0
+    else
+        local cfgfile
+        for cfgfile in "${profile}/syslinux/"*'.cfg'; do
+            if [[ -e "${cfgfile}" ]]; then
+                break
+            else
+                (( validation_error=validation_error+1 ))
+                _msg_error "Validating '${bootmode}': No configuration file found in '${profile}/syslinux/'!" 0
+            fi
+        done
+    fi
+
+    # Check for optional packages
+    # shellcheck disable=SC2076
+    if [[ ! " ${pkg_list[*]} " =~ ' memtest86+ ' ]]; then
+        _msg_info "Validating '${bootmode}': 'memtest86+' is not in the package list. Memmory testing will not be available from syslinux."
+    fi
+}
+
+_validate_requirements_bootmode_bios.syslinux.eltorito() {
+    # bios.syslinux.eltorito has the exact same requirements as bios.syslinux.mbr
+    _validate_requirements_bootmode_bios.syslinux.mbr
+}
+
+_validate_requirements_common_systemd-boot() {
+    # Check if mkfs.fat is available
+    if ! command -v mkfs.fat &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': mkfs.fat is not available on this host. Install 'dosfstools'!" 0
+    fi
+
+    # Check if mmd and mcopy are available
+    if ! { command -v mmd &>/dev/null && command -v mcopy &>/dev/null; }; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': mmd and/or mcopy are not available on this host. Install 'mtools'!" 0
+    fi
+
+    # Check if systemd-boot configuration files exist
+    if [[ ! -d "${profile}/efiboot/loader/entries" ]]; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': The '${profile}/efiboot/loader/entries' directory is missing!" 0
+    else
+        if [[ ! -e "${profile}/efiboot/loader/loader.conf" ]]; then
+            (( validation_error=validation_error+1 ))
+            _msg_error "Validating '${bootmode}': File '${profile}/efiboot/loader/loader.conf' not found!" 0
+        fi
+        local conffile
+        for conffile in "${profile}/efiboot/loader/entries/"*'.conf'; do
+            if [[ -e "${conffile}" ]]; then
+                break
+            else
+                (( validation_error=validation_error+1 ))
+                _msg_error "Validating '${bootmode}': No configuration file found in '${profile}/efiboot/loader/entries/'!" 0
+            fi
+        done
+    fi
+
+    # Check for optional packages
+    # shellcheck disable=SC2076
+    if [[ ! " ${pkg_list[*]} " =~ ' edk2-shell ' ]]; then
+        _msg_info "'edk2-shell' is not in the package list. The ISO will not contain a bootable UEFI shell."
+    fi
+}
+
+_validate_requirements_bootmode_uefi-x64.systemd-boot.esp() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.grub.esp ' ]]; then
+        _msg_error "Validating '${bootmode}': cannot be used with bootmode uefi-x64.grub.esp!" 0
+    fi
+    _validate_requirements_common_systemd-boot
+
+    # shellcheck disable=SC2076
+    if [[ ! " ${pkg_list[*]} " =~ ' memtest86+-efi ' ]]; then
+        _msg_info "Validating '${bootmode}': 'memtest86+-efi' is not in the package list. Memory testing will not be available from systemd-boot."
+    fi
+}
+
+_validate_requirements_bootmode_uefi-x64.systemd-boot.eltorito() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.grub.eltorito ' ]]; then
+        _msg_error "Validating '${bootmode}': cannot be used with bootmode uefi-x64.grub.eltorito!" 0
+    fi
+
+    # uefi-x64.systemd-boot.eltorito has the exact same requirements as uefi-x64.systemd-boot.esp
+    _validate_requirements_bootmode_uefi-x64.systemd-boot.esp
+}
+
+_validate_requirements_bootmode_uefi-ia32.systemd-boot.esp() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-ia32.grub.esp ' ]]; then
+        _msg_error "Validating '${bootmode}': cannot be used with bootmode uefi-ia32.grub.esp!" 0
+    fi
+
+    _validate_requirements_common_systemd-boot
+}
+
+_validate_requirements_bootmode_uefi-ia32.systemd-boot.eltorito() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-ia32.grub.eltorito ' ]]; then
+        _msg_error "Validating '${bootmode}': cannot be used with bootmode uefi-ia32.grub.eltorito!" 0
+    fi
+
+    # uefi-ia32.systemd-boot.eltorito has the exact same requirements as uefi-ia32.systemd-boot.esp
+    _validate_requirements_bootmode_uefi-ia32.systemd-boot.esp
+}
+
+_validate_requirements_bootmode_uefi-ia32.grub.esp() {
+    # Check if GRUB is available
+    if ! command -v grub-mkstandalone &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': grub-install is not available on this host. Install 'grub'!" 0
+    fi
+
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.esp ' ]]; then
+        _validate_requirements_bootmode_uefi-x64.systemd-boot.esp
+    elif [[ " ${bootmodes[*]} " =~ ' uefi-x64.grub.esp ' ]]; then
+        _validate_requirements_bootmode_uefi-x64.grub.esp
+    else
+        _msg_error "Validating '${bootmode}': requires one of bootmode uefi-x64.systemd-boot.esp or uefi-x64.grub.esp" 0
+    fi
+}
+
+_validate_requirements_bootmode_uefi-ia32.grub.eltorito() {
+    # uefi-ia32.grub.eltorito has the exact same requirements as uefi-ia32.grub.esp
+    _validate_requirements_bootmode_uefi-ia32.grub.esp
+}
+
+_validate_requirements_bootmode_uefi-x64.grub.esp() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.esp ' ]]; then
+        _msg_error "Validating '${bootmode}': cannot be used with bootmode uefi-x64.systemd-boot.esp!" 0
+    fi
+
+    # Check if GRUB is available
+    if ! command -v grub-mkstandalone &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': grub-install is not available on this host. Install 'grub'!" 0
+    fi
+
+        # Check if mkfs.fat is available
+    if ! command -v mkfs.fat &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': mkfs.fat is not available on this host. Install 'dosfstools'!" 0
+    fi
+
+    # Check if mmd and mcopy are available
+    if ! { command -v mmd &>/dev/null && command -v mcopy &>/dev/null; }; then
+        _msg_error "Validating '${bootmode}': mmd and/or mcopy are not available on this host. Install 'mtools'!" 0
+    fi
+
+    # Check if GRUB configuration files exist
+    if [[ ! -d "${profile}/grub" ]]; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${bootmode}': The '${profile}/grub' directory is missing!" 0
+    else
+        if [[ ! -e "${profile}/grub/grub.cfg" ]]; then
+            (( validation_error=validation_error+1 ))
+            _msg_error "Validating '${bootmode}': File '${profile}/grub/grub.cfg' not found!" 0
+        fi
+        local conffile
+        for conffile in "${profile}/grub/"*'.cfg'; do
+            if [[ -e "${conffile}" ]]; then
+                break
+            else
+                (( validation_error=validation_error+1 ))
+                _msg_error "Validating '${bootmode}': No configuration file found in '${profile}/grub/'!" 0
+            fi
+        done
+    fi
+
+    # Check for optional packages
+    # shellcheck disable=SC2076
+    if [[ ! " ${pkg_list[*]} " =~ ' edk2-shell ' ]]; then
+        _msg_info "'edk2-shell' is not in the package list. The ISO will not contain a bootable UEFI shell."
+    fi
+    # shellcheck disable=SC2076
+    if [[ ! " ${pkg_list[*]} " =~ ' memtest86+-efi ' ]]; then
+        _msg_info "Validating '${bootmode}': 'memtest86+-efi' is not in the package list. Memory testing will not be available from GRUB."
+    fi
+}
+
+_validate_requirements_bootmode_uefi-x64.grub.eltorito() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.eltorito ' ]]; then
+        _msg_error "Validating '${bootmode}': cannot be used with bootmode uefi-x64.systemd-boot.eltorito!" 0
+    fi
+    # uefi-x64.grub.eltorito has the exact same requirements as uefi-x64.grub.esp
+    _validate_requirements_bootmode_uefi-x64.grub.esp
+}
+
+# Build airootfs filesystem image
+_prepare_airootfs_image() {
+    _run_once "_mkairootfs_${airootfs_image_type}"
+    _mkchecksum
+
+    if [[ -e "${isofs_dir}/${install_dir}/${arch}/airootfs.sfs" ]]; then
+        airootfs_image_filename="${isofs_dir}/${install_dir}/${arch}/airootfs.sfs"
+    elif [[ -e "${isofs_dir}/${install_dir}/${arch}/airootfs.erofs" ]]; then
+        airootfs_image_filename="${isofs_dir}/${install_dir}/${arch}/airootfs.erofs"
+    fi
+
+    if [[ -n "${gpg_key}" ]]; then
+        _mk_pgp_signature "${airootfs_image_filename}"
+    fi
+    if [[ -v cert_list ]]; then
+        _cms_sign_artifact "${airootfs_image_filename}"
+    fi
+}
+
+# export build artifacts for netboot
+_export_netboot_artifacts() {
+    _msg_info "Exporting netboot artifacts..."
+    install -d -m 0755 "${out_dir}"
+    cp -a -- "${isofs_dir}/${install_dir}/" "${out_dir}/"
+
+    # Remove grubenv since it serves no purpose in netboot artifacts
+    rm -f -- "${out_dir}/${install_dir}/grubenv"
+
+    _msg_info "Done!"
+    du -hs -- "${out_dir}/${install_dir}"
+}
+
+_cms_sign_artifact() {
+    local artifact="${1}"
+    local openssl_flags=(
+        "-sign"
+        "-binary"
+        "-nocerts"
+        "-noattr"
+        "-outform" "DER" "-out" "${artifact}.cms.sig"
+        "-in" "${artifact}"
+        "-signer" "${cert_list[0]}"
+        "-inkey" "${cert_list[1]}"
+    )
+
+    if (( ${#cert_list[@]} > 2 )); then
+        openssl_flags+=("-certfile" "${cert_list[2]}")
+    fi
+
+    _msg_info "Signing ${artifact} image using openssl cms..."
+
+    rm -f -- "${artifact}.cms.sig"
+
+    openssl cms "${openssl_flags[@]}"
+
+    _msg_info "Done!"
+}
+
+# sign build artifacts for netboot
+_sign_netboot_artifacts() {
+    local _file _dir
+    local _files_to_sign=()
+    _msg_info "Signing netboot artifacts..."
+    _dir="${isofs_dir}/${install_dir}/boot/"
+    for _file in "${ucodes[@]}"; do
+        if [[ -e "${_dir}${_file}" ]]; then
+            _files_to_sign+=("${_dir}${_file}")
+        fi
+    done
+    for _file in "${_files_to_sign[@]}" "${_dir}${arch}/vmlinuz-"!(*.sig) "${_dir}${arch}/initramfs-"*.img; do
+        rm -f -- "${_file}".ipxe.sig
+        openssl cms \
+            -sign \
+            -binary \
+            -noattr \
+            -in "${_file}" \
+            -signer "${cert_list[0]}" \
+            -inkey "${cert_list[1]}" \
+            -outform DER \
+            -out "${_file}".ipxe.sig
+    done
+    _msg_info "Done!"
+}
+
+_validate_requirements_airootfs_image_type_squashfs() {
+    if ! command -v mksquashfs &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${airootfs_image_type}': mksquashfs is not available on this host. Install 'squashfs-tools'!" 0
+    fi
+}
+
+_validate_requirements_airootfs_image_type_ext4+squashfs() {
+    if ! { command -v mkfs.ext4 &>/dev/null && command -v tune2fs &>/dev/null; }; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${airootfs_image_type}': mkfs.ext4 and/or tune2fs is not available on this host. Install 'e2fsprogs'!" 0
+    fi
+    _validate_requirements_airootfs_image_type_squashfs
+}
+
+_validate_requirements_airootfs_image_type_erofs() {
+    if ! command -v mkfs.erofs &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating '${airootfs_image_type}': mkfs.erofs is not available on this host. Install 'erofs-utils'!" 0
+    fi
+}
+
+_validate_common_requirements_buildmode_all() {
+    if ! command -v pacman &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating build mode '${_buildmode}': pacman is not available on this host. Install 'pacman'!" 0
+    fi
+    if ! command -v find &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating build mode '${_buildmode}': find is not available on this host. Install 'findutils'!" 0
+    fi
+    if ! command -v gzip &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating build mode '${_buildmode}': gzip is not available on this host. Install 'gzip'!" 0
+    fi
+}
+
+_validate_requirements_buildmode_bootstrap() {
+    local bootstrap_pkg_list_from_file=()
+
+    # Check if packages for the bootstrap image are specified
+    if [[ -e "${bootstrap_packages}" ]]; then
+        mapfile -t bootstrap_pkg_list_from_file < \
+            <(sed '/^[[:blank:]]*#.*/d;s/#.*//;/^[[:blank:]]*$/d' "${bootstrap_packages}")
+        bootstrap_pkg_list+=("${bootstrap_pkg_list_from_file[@]}")
+        if (( ${#bootstrap_pkg_list_from_file[@]} < 1 )); then
+            (( validation_error=validation_error+1 ))
+            _msg_error "No package specified in '${bootstrap_packages}'." 0
+        fi
+    else
+        (( validation_error=validation_error+1 ))
+        _msg_error "Bootstrap packages file '${bootstrap_packages}' does not exist." 0
+    fi
+
+    _validate_common_requirements_buildmode_all
+    if ! command -v bsdtar &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating build mode '${_buildmode}': bsdtar is not available on this host. Install 'libarchive'!" 0
+    fi
+
+    # Check if the compressor is installed
+    if (( ${#bootstrap_tarball_compression[@]} )); then
+        case "${bootstrap_tarball_compression[0]}" in
+            'bzip'|'gzip'|'lrzip'|'lzip'|'lzop'|'xz'|'zstd'|'zstdmt')
+                if ! command -v "${bootstrap_tarball_compression[0]}" &>/dev/null; then
+                    (( validation_error=validation_error+1 ))
+                    _msg_error "Validating build mode '${_buildmode}': '${bootstrap_tarball_compression[0]}' is not available on this host. Install '${bootstrap_tarball_compression[0]/zstdmt/zstd}'!" 0
+                fi
+                ;;
+            'cat')
+                if ! command -v cat &>/dev/null; then
+                    (( validation_error=validation_error+1 ))
+                    _msg_error "Validating build mode '${_buildmode}': 'cat' is not available on this host. Install 'coreutils'!" 0
+                fi
+                if (( ${#bootstrap_tarball_compression[@]} > 1 )); then
+                    (( validation_error=validation_error+1 ))
+                    _msg_error "Validating build mode '${_buildmode}': 'cat' compression does not accept arguments!" 0
+                fi
+                ;;
+            *)
+                (( validation_error=validation_error+1 ))
+                _msg_error "Validating build mode '${_buildmode}': '${bootstrap_tarball_compression[0]}' is not a supported compression method!" 0
+                ;;
+        esac
+    fi
+}
+
+_validate_common_requirements_buildmode_iso_netboot() {
+    local bootmode
+    local pkg_list_from_file=()
+
+    # Check if the package list file exists and read packages from it
+    if [[ -e "${packages}" ]]; then
+        mapfile -t pkg_list_from_file < <(sed '/^[[:blank:]]*#.*/d;s/#.*//;/^[[:blank:]]*$/d' "${packages}")
+        pkg_list+=("${pkg_list_from_file[@]}")
+        if (( ${#pkg_list_from_file[@]} < 1 )); then
+            (( validation_error=validation_error+1 ))
+            _msg_error "No package specified in '${packages}'." 0
+        fi
+    else
+        (( validation_error=validation_error+1 ))
+        _msg_error "Packages file '${packages}' does not exist." 0
+    fi
+
+    if [[ -v cert_list ]]; then
+        # Check if the certificate files exist
+        for _cert in "${cert_list[@]}"; do
+            if [[ ! -e "${_cert}" ]]; then
+                (( validation_error=validation_error+1 ))
+                _msg_error "File '${_cert}' does not exist." 0
+            fi
+        done
+        # Check if there are at least three certificate files to sign netboot and rootfs.
+        if (( ${#cert_list[@]} < 2 )); then
+            (( validation_error=validation_error+1 ))
+            _msg_error "Two certificates are required for codesigning netboot artifacts, but '${cert_list[*]}' is provided." 0
+        fi
+
+        if ! command -v openssl &>/dev/null; then
+            (( validation_error=validation_error+1 ))
+            _msg_error "Validating build mode '${_buildmode}': openssl is not available on this host. Install 'openssl'!" 0
+        fi
+    fi
+
+    # Check if the specified airootfs_image_type is supported
+    if typeset -f "_mkairootfs_${airootfs_image_type}" &>/dev/null; then
+        if typeset -f "_validate_requirements_airootfs_image_type_${airootfs_image_type}" &>/dev/null; then
+            "_validate_requirements_airootfs_image_type_${airootfs_image_type}"
+        else
+            _msg_warning "Function '_validate_requirements_airootfs_image_type_${airootfs_image_type}' does not exist. Validating the requirements of '${airootfs_image_type}' airootfs image type will not be possible."
+        fi
+    else
+        (( validation_error=validation_error+1 ))
+        _msg_error "Unsupported image type: '${airootfs_image_type}'" 0
+    fi
+}
+
+_validate_requirements_buildmode_iso() {
+    _validate_common_requirements_buildmode_iso_netboot
+    _validate_common_requirements_buildmode_all
+    # Check if the specified bootmodes are supported
+    if (( ${#bootmodes[@]} < 1 )); then
+        (( validation_error=validation_error+1 ))
+        _msg_error "No boot modes specified in '${profile}/profiledef.sh'." 0
+    fi
+    for bootmode in "${bootmodes[@]}"; do
+        if typeset -f "_make_bootmode_${bootmode}" &>/dev/null; then
+            if typeset -f "_validate_requirements_bootmode_${bootmode}" &>/dev/null; then
+                "_validate_requirements_bootmode_${bootmode}"
+            else
+                _msg_warning "Function '_validate_requirements_bootmode_${bootmode}' does not exist. Validating the requirements of '${bootmode}' boot mode will not be possible."
+            fi
+        else
+            (( validation_error=validation_error+1 ))
+            _msg_error "${bootmode} is not a valid boot mode!" 0
+        fi
+    done
+
+    if ! command -v awk &>/dev/null; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "Validating build mode '${_buildmode}': awk is not available on this host. Install 'awk'!" 0
+    fi
+}
+
+_validate_requirements_buildmode_netboot() {
+    _validate_common_requirements_buildmode_iso_netboot
+    _validate_common_requirements_buildmode_all
+}
+
+# SYSLINUX El Torito
+_add_xorrisofs_options_bios.syslinux.eltorito() {
+    xorrisofs_options+=(
+        # El Torito boot image for x86 BIOS
+        '-eltorito-boot' 'boot/syslinux/isolinux.bin'
+        # El Torito boot catalog file
+        '-eltorito-catalog' 'boot/syslinux/boot.cat'
+        # Required options to boot with ISOLINUX
+        '-no-emul-boot' '-boot-load-size' '4' '-boot-info-table'
+    )
+}
+
+# SYSLINUX MBR (isohybrid)
+_add_xorrisofs_options_bios.syslinux.mbr() {
+    xorrisofs_options+=(
+        # SYSLINUX MBR bootstrap code; does not work without "-eltorito-boot syslinux/isolinux.bin"
+        '-isohybrid-mbr' "${isofs_dir}/boot/syslinux/isohdpfx.bin"
+        # When GPT is used, create an additional partition in the MBR (besides 0xEE) for sectors 0–1 (MBR
+        # bootstrap code area) and mark it as bootable
+        # May allow booting on some systems
+        # https://wiki.archlinux.org/title/Partitioning#Tricking_old_BIOS_into_booting_from_GPT
+        '--mbr-force-bootable'
+        # Move the first partition away from the start of the ISO to match the expectations of partition editors
+        # May allow booting on some systems
+        # https://dev.lovelyhq.com/libburnia/libisoburn/src/branch/master/doc/partition_offset.wiki
+        '-partition_offset' '16'
+    )
+}
+
+# GRUB in an attached EFI system partition
+_add_xorrisofs_options_uefi-ia32.grub.esp() {
+    # TODO: how does the bootmodes systemd-boot vs x64.grub affect ${bootmodes[*]} tests in _add_xorrisofs_options_uefi-x64.systemd-boot.esp etc?
+    # shellcheck disable=SC2076
+    if [[ ! " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.esp ' && ! " ${bootmodes[*]} " =~ ' uefi-x64.grub.esp ' ]]; then
+        # _add_xorrisofs_options_uefi-x64.systemd-boot.esp
+        _add_xorrisofs_options_uefi-x64.grub.esp
+    fi
+}
+
+# GRUB via El Torito
+_add_xorrisofs_options_uefi-ia32.grub.eltorito() {
+    # shellcheck disable=SC2076
+    if [[ ! " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.eltorito ' && ! " ${bootmodes[*]} " =~ ' uefi-x64.grub.eltorito ' ]]; then
+        # _add_xorrisofs_options_uefi-x64.systemd-boot.eltorito
+        _add_xorrisofs_options_uefi-x64.grub.eltorito
+    fi
+}
+
+# systemd-boot in an attached EFI system partition
+_add_xorrisofs_options_uefi-x64.systemd-boot.esp() {
+    # Move the first partition away from the start of the ISO, otherwise the GPT will not be valid and ISO 9660
+    # partition will not be mountable
+    # shellcheck disable=SC2076
+    [[ " ${xorrisofs_options[*]} " =~ ' -partition_offset ' ]] || xorrisofs_options+=('-partition_offset' '16')
+    # Attach efiboot.img as a second partition and set its partition type to "EFI system partition"
+    xorrisofs_options+=('-append_partition' '2' 'C12A7328-F81F-11D2-BA4B-00A0C93EC93B' "${efibootimg}")
+    # Ensure GPT is used as some systems do not support UEFI booting without it
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' bios.syslinux.mbr ' ]]; then
+        # A valid GPT prevents BIOS booting on some systems, instead use an invalid GPT (without a protective MBR).
+        # The attached partition will have the EFI system partition type code in MBR, but in the invalid GPT it will
+        # have a Microsoft basic partition type code.
+        if [[ ! " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.eltorito ' && ! " ${bootmodes[*]} " =~ ' uefi-ia32.grub.eltorito ' ]]; then
+            # If '-isohybrid-gpt-basdat' is specified before '-e', then the appended EFI system partition will have the
+            # EFI system partition type ID/GUID in both MBR and GPT. If '-isohybrid-gpt-basdat' is specified after '-e',
+            # the appended EFI system partition will have the Microsoft basic data type GUID in GPT.
+            if [[ ! " ${xorrisofs_options[*]} " =~ ' -isohybrid-gpt-basdat ' ]]; then
+                xorrisofs_options+=('-isohybrid-gpt-basdat')
+            fi
+        fi
+    else
+        # Use valid GPT if BIOS booting support will not be required
+        xorrisofs_options+=('-appended_part_as_gpt')
+    fi
+}
+
+# systemd-boot via El Torito
+_add_xorrisofs_options_uefi-x64.systemd-boot.eltorito() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.systemd-boot.esp ' || " ${bootmodes[*]} " =~ ' uefi-ia32.grub.esp ' ]]; then
+        # systemd-boot in an attached EFI system partition via El Torito
+        xorrisofs_options+=(
+            # Start a new El Torito boot entry for UEFI
+            '-eltorito-alt-boot'
+            # Set the second partition as the El Torito UEFI boot image
+            '-e' '--interval:appended_partition_2:all::'
+            # Boot image is not emulating floppy or hard disk; required for all known boot loaders
+            '-no-emul-boot'
+        )
+        # A valid GPT prevents BIOS booting on some systems, use an invalid GPT instead.
+        if [[ " ${bootmodes[*]} " =~ ' bios.syslinux.mbr ' ]]; then
+            # If '-isohybrid-gpt-basdat' is specified before '-e', then the appended EFI system partition will have the
+            # EFI system partition type ID/GUID in both MBR and GPT. If '-isohybrid-gpt-basdat' is specified after '-e',
+            # the appended EFI system partition will have the Microsoft basic data type GUID in GPT.
+            if [[ ! " ${xorrisofs_options[*]} " =~ ' -isohybrid-gpt-basdat ' ]]; then
+                xorrisofs_options+=('-isohybrid-gpt-basdat')
+            fi
+        fi
+    else
+        # The ISO will not contain a GPT partition table, so to be able to reference efiboot.img, place it as a
+        # file inside the ISO 9660 file system
+        install -d -m 0755 -- "${isofs_dir}/EFI/archiso"
+        cp -a -- "${efibootimg}" "${isofs_dir}/EFI/archiso/efiboot.img"
+        # systemd-boot in an embedded efiboot.img via El Torito
+        xorrisofs_options+=(
+            # Start a new El Torito boot entry for UEFI
+            '-eltorito-alt-boot'
+            # Set efiboot.img as the El Torito UEFI boot image
+            '-e' 'EFI/archiso/efiboot.img'
+            # Boot image is not emulating floppy or hard disk; required for all known boot loaders
+            '-no-emul-boot'
+        )
+    fi
+    # Specify where to save the El Torito boot catalog file in case it is not already set by bios.syslinux.eltorito
+    # shellcheck disable=SC2076
+    [[ " ${bootmodes[*]} " =~ ' bios.' ]] || xorrisofs_options+=('-eltorito-catalog' 'EFI/boot.cat')
+}
+
+# GRUB in an attached EFI system partition.
+# Same as _add_xorrisofs_options_uefi-x64.systemd-boot.esp.
+_add_xorrisofs_options_uefi-x64.grub.esp() {
+    # Move the first partition away from the start of the ISO, otherwise the GPT will not be valid and ISO 9660
+    # partition will not be mountable
+    # shellcheck disable=SC2076
+    [[ " ${xorrisofs_options[*]} " =~ ' -partition_offset ' ]] || xorrisofs_options+=('-partition_offset' '16')
+    # Attach efiboot.img as a second partition and set its partition type to "EFI system partition"
+    xorrisofs_options+=('-append_partition' '2' 'C12A7328-F81F-11D2-BA4B-00A0C93EC93B' "${efibootimg}")
+    # Ensure GPT is used as some systems do not support UEFI booting without it
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' bios.syslinux.mbr ' ]]; then
+        # A valid GPT prevents BIOS booting on some systems, instead use an invalid GPT (without a protective MBR).
+        # The attached partition will have the EFI system partition type code in MBR, but in the invalid GPT it will
+        # have a Microsoft basic partition type code.
+        if [[ ! " ${bootmodes[*]} " =~ ' uefi-x64.grub.eltorito ' && ! " ${bootmodes[*]} " =~ ' uefi-ia32.grub.eltorito ' ]]; then
+            # If '-isohybrid-gpt-basdat' is specified before '-e', then the appended EFI system partition will have the
+            # EFI system partition type ID/GUID in both MBR and GPT. If '-isohybrid-gpt-basdat' is specified after '-e',
+            # the appended EFI system partition will have the Microsoft basic data type GUID in GPT.
+            if [[ ! " ${xorrisofs_options[*]} " =~ ' -isohybrid-gpt-basdat ' ]]; then
+                xorrisofs_options+=('-isohybrid-gpt-basdat')
+            fi
+        fi
+    else
+        # Use valid GPT if BIOS booting support will not be required
+        xorrisofs_options+=('-appended_part_as_gpt')
+    fi
+}
+
+# GRUB via El Torito
+# Same as _add_xorrisofs_options_uefi-x64.systemd-boot.eltorito.
+_add_xorrisofs_options_uefi-x64.grub.eltorito() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-x64.grub.esp ' || " ${bootmodes[*]} " =~ ' uefi-ia32.grub.esp ' ]]; then
+        # grub in an attached EFI system partition via El Torito
+        xorrisofs_options+=(
+            # Start a new El Torito boot entry for UEFI
+            '-eltorito-alt-boot'
+            # Set the second partition as the El Torito UEFI boot image
+            '-e' '--interval:appended_partition_2:all::'
+            # Boot image is not emulating floppy or hard disk; required for all known boot loaders
+            '-no-emul-boot'
+        )
+        # A valid GPT prevents BIOS booting on some systems, use an invalid GPT instead.
+        if [[ " ${bootmodes[*]} " =~ ' bios.syslinux.mbr ' ]]; then
+            # If '-isohybrid-gpt-basdat' is specified before '-e', then the appended EFI system partition will have the
+            # EFI system partition type ID/GUID in both MBR and GPT. If '-isohybrid-gpt-basdat' is specified after '-e',
+            # the appended EFI system partition will have the Microsoft basic data type GUID in GPT.
+            if [[ ! " ${xorrisofs_options[*]} " =~ ' -isohybrid-gpt-basdat ' ]]; then
+                xorrisofs_options+=('-isohybrid-gpt-basdat')
+            fi
+        fi
+    else
+        # The ISO will not contain a GPT partition table, so to be able to reference efiboot.img, place it as a
+        # file inside the ISO 9660 file system
+        install -d -m 0755 -- "${isofs_dir}/EFI/archiso"
+        cp -a -- "${efibootimg}" "${isofs_dir}/EFI/archiso/efiboot.img"
+        # grub in an embedded efiboot.img via El Torito
+        xorrisofs_options+=(
+            # Start a new El Torito boot entry for UEFI
+            '-eltorito-alt-boot'
+            # Set efiboot.img as the El Torito UEFI boot image
+            '-e' 'EFI/archiso/efiboot.img'
+            # Boot image is not emulating floppy or hard disk; required for all known boot loaders
+            '-no-emul-boot'
+        )
+    fi
+    # Specify where to save the El Torito boot catalog file in case it is not already set by bios.syslinux.eltorito
+    # shellcheck disable=SC2076
+    [[ " ${bootmodes[*]} " =~ ' bios.' ]] || xorrisofs_options+=('-eltorito-catalog' 'EFI/boot.cat')
+}
+
+
+#loongarch64
+_add_xorrisofs_options_uefi-loong64.grub.esp() {
+    # Move the first partition away from the start of the ISO, otherwise the GPT will not be valid and ISO 9660
+    # partition will not be mountable
+    # shellcheck disable=SC2076
+    [[ " ${xorrisofs_options[*]} " =~ ' -partition_offset ' ]] || xorrisofs_options+=('-partition_offset' '16')
+    # Attach efiboot.img as a second partition and set its partition type to "EFI system partition"
+    xorrisofs_options+=('-append_partition' '2' 'C12A7328-F81F-11D2-BA4B-00A0C93EC93B' "${efibootimg}")
+}
+_add_xorrisofs_options_uefi-loong64.grub.eltorito() {
+    # shellcheck disable=SC2076
+    if [[ " ${bootmodes[*]} " =~ ' uefi-loong64.grub.esp ' ]]; then
+        # grub in an attached EFI system partition via El Torito
+        xorrisofs_options+=(
+            # Start a new El Torito boot entry for UEFI
+            '-eltorito-alt-boot'
+            # Set the second partition as the El Torito UEFI boot image
+            '-e' '--interval:appended_partition_2:all::'
+            # Boot image is not emulating floppy or hard disk; required for all known boot loaders
+            '-no-emul-boot'
+        )
+    else
+        # The ISO will not contain a GPT partition table, so to be able to reference efiboot.img, place it as a
+        # file inside the ISO 9660 file system
+        install -d -m 0755 -- "${isofs_dir}/EFI/archiso"
+        cp -a -- "${efibootimg}" "${isofs_dir}/EFI/archiso/efiboot.img"
+        # grub in an embedded efiboot.img via El Torito
+        xorrisofs_options+=(
+            # Start a new El Torito boot entry for UEFI
+            '-eltorito-alt-boot'
+            # Set efiboot.img as the El Torito UEFI boot image
+            '-e' 'EFI/archiso/efiboot.img'
+            # Boot image is not emulating floppy or hard disk; required for all known boot loaders
+            '-no-emul-boot'
+        )
+    fi
+    # Specify where to save the El Torito boot catalog file in case it is not already set by bios.syslinux.eltorito
+    # shellcheck disable=SC2076
+    [[ " ${bootmodes[*]} " =~ ' bios.' ]] || xorrisofs_options+=('-eltorito-catalog' 'EFI/boot.cat')
+}
+
+
+# Build bootstrap image
+_build_bootstrap_image() {
+    # Set default tarball compression to uncompressed
+    if (( ! "${#bootstrap_tarball_compression[@]}" )); then
+        bootstrap_tarball_compression=('cat')
+    fi
+
+    [[ -d "${out_dir}" ]] || install -d -- "${out_dir}"
+
+    cd -- "${bootstrap_parent}"
+
+    _msg_info "Creating bootstrap image..."
+    rm -f -- "${out_dir:?}/${image_name:?}"
+    bsdtar -cf - "root.${arch}" "pkglist.${arch}.txt" | "${bootstrap_tarball_compression[@]}" >"${out_dir}/${image_name}"
+    _msg_info "Done!"
+    du -h -- "${out_dir}/${image_name}"
+    cd -- "${OLDPWD}"
+}
+
+# Build ISO
+_build_iso_image() {
+    local xorriso_options=() xorrisofs_options=()
+    local bootmode
+
+    [[ -d "${out_dir}" ]] || install -d -- "${out_dir}"
+
+    # Do not read xorriso startup files to prevent interference and unintended behavior.
+    # For it to work, -no_rc must be the first argument passed to xorriso.
+    xorriso_options=('-no_rc')
+
+
+    if [[ "${quiet}" == "y" ]]; then
+        # The when xorriso is run in mkisofs compatibility mode (xorrisofs), the mkisofs option -quiet is interpreted
+        # too late (e.g. messages about SOURCE_DATE_EPOCH still get shown).
+        # Instead use native xorriso option to silence the output.
+        xorriso_options+=('-report_about' 'SORRY')
+    fi
+
+    # Add required xorrisofs options for each boot mode
+    for bootmode in "${bootmodes[@]}"; do
+        typeset -f "_add_xorrisofs_options_${bootmode}" &>/dev/null && "_add_xorrisofs_options_${bootmode}"
+    done
+
+    # Remove 300 KiB padding needed for CDs if the ISO exceeds the max size of a CD
+    if (( $(du -s --apparent-size -B1M "${isofs_dir}/" | awk '{ print $1 }') > 900 )); then
+        xorrisofs_options+=('-no-pad')
+    fi
+
+    rm -f -- "${out_dir}/${image_name}"
+    _msg_info "Creating ISO image..."
+    xorriso "${xorriso_options[@]}" -as mkisofs \
+        -iso-level 3 \
+        -full-iso9660-filenames \
+        -joliet \
+        -joliet-long \
+        -rational-rock \
+        -volid "${iso_label}" \
+        -appid "${iso_application}" \
+        -publisher "${iso_publisher}" \
+        -preparer "prepared by ${app_name}" \
+        "${xorrisofs_options[@]}" \
+        -output "${out_dir}/${image_name}" \
+        "${isofs_dir}/"
+    _msg_info "Done!"
+    du -h -- "${out_dir}/${image_name}"
+}
+
+# Read profile's values from profiledef.sh
+_read_profile() {
+    if [[ -z "${profile}" ]]; then
+        _msg_error "No profile specified!" 1
+    fi
+    if [[ ! -d "${profile}" ]]; then
+        _msg_error "Profile '${profile}' does not exist!" 1
+    elif [[ ! -e "${profile}/profiledef.sh" ]]; then
+        _msg_error "Profile '${profile}' is missing 'profiledef.sh'!" 1
+    else
+        cd -- "${profile}"
+
+        # Source profile's variables
+        # shellcheck source=configs/releng/profiledef.sh
+        . "${profile}/profiledef.sh"
+
+        # Resolve paths of files that are expected to reside in the profile's directory
+        [[ -n "$arch" ]] || arch="$(uname -m)"
+        [[ -n "$packages" ]] || packages="${profile}/packages.${arch}"
+        packages="$(realpath -- "${packages}")"
+        pacman_conf="$(realpath -- "${pacman_conf}")"
+
+        # Resolve paths of files that may reside in the profile's directory
+        if [[ -z "$bootstrap_packages" ]] && [[ -e "${profile}/bootstrap_packages.${arch}" ]]; then
+            bootstrap_packages="${profile}/bootstrap_packages.${arch}"
+            bootstrap_packages="$(realpath -- "${bootstrap_packages}")"
+            pacman_conf="$(realpath -- "${pacman_conf}")"
+        fi
+
+        cd -- "${OLDPWD}"
+    fi
+}
+
+# Validate set options
+_validate_options() {
+    local validation_error=0 _buildmode certfile
+
+    _msg_info "Validating options..."
+
+    # Check if pacman configuration file exists
+    if [[ ! -e "${pacman_conf}" ]]; then
+        (( validation_error=validation_error+1 ))
+        _msg_error "File '${pacman_conf}' does not exist." 0
+    fi
+
+    # Check if the code signing certificate files exist
+    for certfile in "${cert_list[@]}"; do
+        if [[ ! -e "$certfile" ]]; then
+            (( validation_error=validation_error+1 ))
+            _msg_error "Code signing certificate '${certfile}' does not exist." 0
+        fi
+    done
+
+    # Check if the specified buildmodes are supported
+    for _buildmode in "${buildmodes[@]}"; do
+        if typeset -f "_build_buildmode_${_buildmode}" &>/dev/null; then
+            if typeset -f "_validate_requirements_buildmode_${_buildmode}" &>/dev/null; then
+                "_validate_requirements_buildmode_${_buildmode}"
+            else
+                _msg_warning "Function '_validate_requirements_buildmode_${_buildmode}' does not exist. Validating the requirements of '${_buildmode}' build mode will not be possible."
+            fi
+        else
+            (( validation_error=validation_error+1 ))
+            _msg_error "${_buildmode} is not a valid build mode!" 0
+        fi
+    done
+
+    if (( validation_error )); then
+        _msg_error "${validation_error} errors were encountered while validating the profile. Aborting." 1
+    fi
+    _msg_info "Done!"
+}
+
+# Set defaults and, if present, overrides from mkarchiso command line option parameters
+_set_overrides() {
+    # Set variables that have command line overrides
+    [[ ! -v override_buildmodes ]] || buildmodes=("${override_buildmodes[@]}")
+    if (( ${#buildmodes[@]} < 1 )); then
+        buildmodes+=('iso')
+    fi
+    if [[ -v override_work_dir ]]; then
+        work_dir="$override_work_dir"
+    elif [[ -z "$work_dir" ]]; then
+        work_dir='./work'
+    fi
+    work_dir="$(realpath -- "$work_dir")"
+    if [[ -v override_out_dir ]]; then
+        out_dir="$override_out_dir"
+    elif [[ -z "$out_dir" ]]; then
+        out_dir='./out'
+    fi
+    out_dir="$(realpath -- "$out_dir")"
+    if [[ -v override_pacman_conf ]]; then
+        pacman_conf="$override_pacman_conf"
+    elif [[ -z "$pacman_conf" ]]; then
+        pacman_conf="/etc/pacman.conf"
+    fi
+    pacman_conf="$(realpath -- "$pacman_conf")"
+    [[ ! -v override_pkg_list ]] || pkg_list+=("${override_pkg_list[@]}")
+    # TODO: allow overriding bootstrap_pkg_list
+    if [[ -v override_iso_label ]]; then
+        iso_label="$override_iso_label"
+    elif [[ -z "$iso_label" ]]; then
+        iso_label="${app_name^^}"
+    fi
+    if [[ -v override_iso_publisher ]]; then
+        iso_publisher="$override_iso_publisher"
+    elif [[ -z "$iso_publisher" ]]; then
+        iso_publisher="${app_name}"
+    fi
+    if [[ -v override_iso_application ]]; then
+        iso_application="$override_iso_application"
+    elif [[ -z "$iso_application" ]]; then
+        iso_application="${app_name} iso"
+    fi
+    if [[ -v override_install_dir ]]; then
+        install_dir="$override_install_dir"
+    elif [[ -z "$install_dir" ]]; then
+        install_dir="${app_name}"
+    fi
+    [[ ! -v override_gpg_key ]] || gpg_key="$override_gpg_key"
+    [[ ! -v override_gpg_sender ]] || gpg_sender="$override_gpg_sender"
+    [[ ! -v override_cert_list ]] || mapfile -t cert_list < <(realpath -- "${override_cert_list[@]}")
+    if [[ -v override_quiet ]]; then
+        quiet="$override_quiet"
+    elif [[ -z "$quiet" ]]; then
+        quiet="y"
+    fi
+    if [[ -v override_rm_work_dir ]]; then
+        rm_work_dir="$override_rm_work_dir"
+    fi
+
+    # Set variables that do not have overrides
+    [[ -n "$airootfs_image_type" ]] || airootfs_image_type="squashfs"
+    [[ -n "$iso_name" ]] || iso_name="${app_name}"
+    # Precalculate the ISO's modification date in UTC, i.e. its "UUID"
+    TZ=UTC printf -v iso_uuid '%(%F-%H-%M-%S-00)T' "$SOURCE_DATE_EPOCH"
+}
+
+_export_gpg_publickey() {
+    gpg_publickey="${work_dir}/pubkey.gpg"
+    rm -f -- "$gpg_publickey"
+    gpg --batch --no-armor --output "$gpg_publickey" --export "${gpg_key}"
+    [[ -s "$gpg_publickey" ]] || return
+}
+
+_make_version() {
+    local _os_release
+
+    _msg_info "Creating version files..."
+    # Write version file to system installation dir
+    rm -f -- "${pacstrap_dir}/version"
+    printf '%s\n' "${iso_version}" >"${pacstrap_dir}/version"
+
+    if [[ "${buildmode}" == @("iso"|"netboot") ]]; then
+        install -d -m 0755 -- "${isofs_dir}/${install_dir}"
+        # Write version file to ISO 9660
+        printf '%s\n' "${iso_version}" >"${isofs_dir}/${install_dir}/version"
+
+    fi
+    if [[ "${buildmode}" == "iso" ]]; then
+        # Write grubenv with version information to ISO 9660
+        # TODO: after sufficient time has passed, do not create this file anymore.
+        #       _make_common_bootmode_grub_cfg and _make_common_grubenv_and_loopbackcfg already create a
+        #       ${isofs_dir}/boot/grub/grubenv file
+        rm -f -- "${isofs_dir}/${install_dir}/grubenv"
+        printf '%.1024s' "$(printf '# GRUB Environment Block\nNAME=%s\nVERSION=%s\n%s' \
+            "${iso_name}" "${iso_version}" "$(printf '%0.1s' "#"{1..1024})")" \
+            >"${isofs_dir}/${install_dir}/grubenv"
+
+        # Create a /boot/YYYY-mm-dd-HH-MM-SS-00.uuid file on ISO 9660. GRUB will search for it to find the ISO
+        # volume. This is similar to what grub-mkrescue does, except it places the file in /.disk/, but we opt to use a
+        # directory that does not start with a dot to avoid it being accidentally missed when copying the ISO's contents.
+        search_filename="/boot/${iso_uuid}.uuid"
+        install -d -m 755 -- "${isofs_dir}/boot"
+        : >"${isofs_dir}${search_filename}"
+    fi
+
+    # Append IMAGE_ID & IMAGE_VERSION to os-release
+    _os_release="$(realpath -- "${pacstrap_dir}/etc/os-release")"
+    if [[ ! -e "${pacstrap_dir}/etc/os-release" && -e "${pacstrap_dir}/usr/lib/os-release" ]]; then
+        _os_release="$(realpath -- "${pacstrap_dir}/usr/lib/os-release")"
+    fi
+    if [[ "${_os_release}" != "${pacstrap_dir}"* ]]; then
+        _msg_warning "os-release file '${_os_release}' is outside of valid path."
+    else
+        [[ ! -e "${_os_release}" ]] || sed -i '/^IMAGE_ID=/d;/^IMAGE_VERSION=/d' "${_os_release}"
+        printf 'IMAGE_ID=%s\nIMAGE_VERSION=%s\n' "${iso_name}" "${iso_version}" >>"${_os_release}"
+    fi
+
+    # Touch /usr/lib/clock-epoch to give another hint on date and time
+    # for systems with screwed or broken RTC.
+    touch -m -d"@${SOURCE_DATE_EPOCH}" -- "${pacstrap_dir}/usr/lib/clock-epoch"
+
+    _msg_info "Done!"
+}
+
+_make_pkglist() {
+    _msg_info "Creating a list of installed packages on live-enviroment..."
+    case "${buildmode}" in
+        "bootstrap")
+            pacman -Q --sysroot "${pacstrap_dir}" >"${bootstrap_parent}/pkglist.${arch}.txt"
+            ;;
+        "iso"|"netboot")
+            install -d -m 0755 -- "${isofs_dir}/${install_dir}"
+            pacman -Q --sysroot "${pacstrap_dir}" >"${isofs_dir}/${install_dir}/pkglist.${arch}.txt"
+            ;;
+    esac
+    _msg_info "Done!"
+}
+
+# Create working directory
+_make_work_dir() {
+    if [[ ! -d "${work_dir}" ]]; then
+        install -d -- "${work_dir}"
+    elif (( rm_work_dir )); then
+        rm_work_dir=0
+        _msg_warning "Working directory removal requested, but '${work_dir}' already exists. It will not be removed!" 0
+    fi
+}
+
+# build the base for an ISO and/or a netboot target
+_build_iso_base() {
+    local run_once_mode="base"
+    local buildmode_packages="${packages}"
+    # Set the package list to use
+    local buildmode_pkg_list=("${pkg_list[@]}")
+    # Set up essential directory paths
+    pacstrap_dir="${work_dir}/${arch}/airootfs"
+    isofs_dir="${work_dir}/iso"
+
+    # Create working directory
+    _run_once _make_work_dir
+    # Write build date to file if it does not exist already
+    [[ -e "${work_dir}/build_date" ]] || printf '%s\n' "$SOURCE_DATE_EPOCH" >"${work_dir}/build_date"
+
+    [[ "${quiet}" == "y" ]] || _show_config
+    _run_once _make_pacman_conf
+    [[ -z "${gpg_key}" ]] || _run_once _export_gpg_publickey
+    _run_once _make_custom_airootfs
+    _run_once _make_packages
+    _run_once _make_version
+    _run_once _make_customize_airootfs
+    _run_once _make_pkglist
+    _run_once _check_if_initramfs_has_ucode
+    if [[ "${buildmode}" == 'netboot' ]]; then
+        _run_once _make_boot_on_iso9660
+    else
+        _make_bootmodes
+    fi
+    _run_once _cleanup_pacstrap_dir
+    _run_once _prepare_airootfs_image
+}
+
+# Build the bootstrap buildmode
+_build_buildmode_bootstrap() {
+    local image_name="${iso_name}-bootstrap-${iso_version}-${arch}.tar"
+    local run_once_mode="${buildmode}"
+    local buildmode_packages="${bootstrap_packages}"
+    # Set the package list to use
+    local buildmode_pkg_list=("${bootstrap_pkg_list[@]}")
+
+    # Set up essential directory paths
+    pacstrap_dir="${work_dir}/${arch}/bootstrap/root.${arch}"
+    bootstrap_parent="$(dirname -- "${pacstrap_dir}")"
+    [[ -d "${work_dir}" ]] || install -d -- "${work_dir}"
+    install -d -m 0755 -o 0 -g 0 -- "${pacstrap_dir}"
+
+    # Set tarball extension
+    case "${bootstrap_tarball_compression[0]}" in
+        'bzip') image_name="${image_name}.b2z" ;;
+        'gzip') image_name="${image_name}.gz" ;;
+        'lrzip') image_name="${image_name}.lrz" ;;
+        'lzip') image_name="${image_name}.lz" ;;
+        'lzop') image_name="${image_name}.lzo" ;;
+        'xz') image_name="${image_name}.xz" ;;
+        'zstd'|'zstdmt') image_name="${image_name}.zst" ;;
+    esac
+
+    [[ "${quiet}" == "y" ]] || _show_config
+    _run_once _make_pacman_conf
+    _run_once _make_packages
+    _run_once _make_version
+    _run_once _make_pkglist
+    _run_once _cleanup_pacstrap_dir
+    _run_once _build_bootstrap_image
+}
+
+# Build the netboot buildmode
+_build_buildmode_netboot() {
+    local run_once_mode="${buildmode}"
+
+    _build_iso_base
+
+    if [[ -e "${isofs_dir}/${install_dir}/${arch}/airootfs.sfs" ]]; then
+        airootfs_image_filename="${isofs_dir}/${install_dir}/${arch}/airootfs.sfs"
+    elif [[ -e "${isofs_dir}/${install_dir}/${arch}/airootfs.erofs" ]]; then
+        airootfs_image_filename="${isofs_dir}/${install_dir}/${arch}/airootfs.erofs"
+    fi
+
+    if [[ -v cert_list ]]; then
+        _run_once _sign_netboot_artifacts
+    fi
+    _run_once _export_netboot_artifacts
+}
+
+# Build the ISO buildmode
+_build_buildmode_iso() {
+    local image_name="${iso_name}-${iso_version}-${arch}.iso"
+    local run_once_mode="${buildmode}"
+    efibootimg="${work_dir}/efiboot.img"
+    _build_iso_base
+    _run_once _build_iso_image
+}
+
+# build all buildmodes
+_build() {
+    local buildmode
+    local run_once_mode="build"
+
+    for buildmode in "${buildmodes[@]}"; do
+        _run_once "_build_buildmode_${buildmode}"
+    done
+    if (( rm_work_dir )); then
+        _msg_info 'Removing the working directory...'
+        rm -rf -- "${work_dir:?}/"
+        _msg_info 'Done!'
+    fi
+}
+
+while getopts 'c:p:C:L:P:A:D:w:m:o:g:G:vrh?' arg; do
+    case "${arg}" in
+        p) read -r -a override_pkg_list <<<"${OPTARG}" ;;
+        C) override_pacman_conf="${OPTARG}" ;;
+        L) override_iso_label="${OPTARG}" ;;
+        P) override_iso_publisher="${OPTARG}" ;;
+        A) override_iso_application="${OPTARG}" ;;
+        D) override_install_dir="${OPTARG}" ;;
+        c) read -r -a override_cert_list <<<"${OPTARG}" ;;
+        w) override_work_dir="${OPTARG}" ;;
+        m) read -r -a override_buildmodes <<<"${OPTARG}" ;;
+        o) override_out_dir="${OPTARG}" ;;
+        g) override_gpg_key="${OPTARG}" ;;
+        G) override_gpg_sender="${OPTARG}" ;;
+        v) override_quiet="n" ;;
+        r) declare -i override_rm_work_dir=1 ;;
+        h|?) _usage 0 ;;
+        *)
+            _msg_error "Invalid argument '${arg}'" 0
+            _usage 1
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+if (( $# < 1 )); then
+    _msg_error "No profile specified" 0
+    _usage 1
+fi
+
+if (( EUID != 0 )); then
+    _msg_error "${app_name} must be run as root." 1
+fi
+
+# get the absolute path representation of the first non-option argument
+profile="$(realpath -- "${1}")"
+
+# Read SOURCE_DATE_EPOCH from file early
+build_date_file="$(realpath -q -- "${override_work_dir:-./work}/build_date")" || :
+if [[ -f "$build_date_file" ]]; then
+    SOURCE_DATE_EPOCH="$(<"$build_date_file")"
+fi
+unset build_date_file
+
+_read_profile
+_set_overrides
+_validate_options
+_build
+
+# vim:ts=4:sw=4:et:

--- a/packages.loong64
+++ b/packages.loong64
@@ -30,14 +30,12 @@ f2fs-tools
 fatresize
 foot-terminfo
 fsarchiver
-gnu-netcat
 gpart
 gpm
 gptfdisk
 grml-zsh-config
 grub
 hdparm
-hyperv
 irssi
 iw
 iwd

--- a/pacman.conf
+++ b/pacman.conf
@@ -36,6 +36,7 @@ Architecture = auto
 #CheckSpace
 #VerbosePkgLists
 ParallelDownloads = 5
+#DisableSandbox
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.
@@ -70,26 +71,26 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 
-[core-testing]
-Include = /etc/pacman.d/mirrorlist
+#[core-testing]
+#Include = /etc/pacman.d/mirrorlist-loong64
 
 [core]
-Include = /etc/pacman.d/mirrorlist
+Include = /etc/pacman.d/mirrorlist-loong64
 
-[extra-testing]
-Include = /etc/pacman.d/mirrorlist
+#[extra-testing]
+#Include = /etc/pacman.d/mirrorlist-loong64
 
 [extra]
-Include = /etc/pacman.d/mirrorlist
+Include = /etc/pacman.d/mirrorlist-loong64
 
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.
 
 #[multilib-testing]
-#Include = /etc/pacman.d/mirrorlist
+#Include = /etc/pacman.d/mirrorlist-loong64
 
 #[multilib]
-#Include = /etc/pacman.d/mirrorlist
+#Include = /etc/pacman.d/mirrorlist-loong64
 
 # An example of a custom package repository.  See the pacman manpage for
 # tips on creating your own repositories.


### PR DESCRIPTION
Official "mkarchiso" doesn't support loong64 bootmodes, I adjusted mkarchiso add functions for loong64 bootmodes, now we can build iso easily 
```sudo ./mkarchiso (-v) .```
or maybe loong should make a brand_new script for isomake.